### PR TITLE
Fix required scope lookup in middleware and add regression test

### DIFF
--- a/src/meta_mcp/middleware.py
+++ b/src/meta_mcp/middleware.py
@@ -247,7 +247,7 @@ class GovernanceMiddleware(Middleware):
             List of required permission scopes
         """
         # Start with base scopes from registry
-        tool_record = tool_registry.get_tool(tool_name)
+        tool_record = tool_registry.get(tool_name)
         if tool_record and tool_record.required_scopes:
             base_scopes = tool_record.required_scopes.copy()
         else:

--- a/tests/test_coverage_completion.py
+++ b/tests/test_coverage_completion.py
@@ -135,6 +135,22 @@ async def test_admin_operations_context_key(
 # ============================================================================
 
 
+def test_get_required_scopes_from_registry():
+    """
+    Test that required scopes are resolved from the registry and include resources.
+
+    Expected: Registry scopes are included along with resource path scope.
+    Coverage: middleware.py lines 250-276
+    """
+    scopes = GovernanceMiddleware._get_required_scopes(
+        "write_file", {"path": "/tmp/example.txt"}
+    )
+
+    assert "tool:write_file" in scopes
+    assert "filesystem:write" in scopes
+    assert "resource:path:/tmp/example.txt" in scopes
+
+
 @pytest.mark.asyncio
 async def test_approval_request_long_argument_truncation(
     governance_in_permission,


### PR DESCRIPTION
### Motivation
- Ensure `_get_required_scopes` resolves base scopes from the existing registry API so approval flows correctly include tool `required_scopes` and to prevent regressions.

### Description
- Replace `tool_registry.get_tool(tool_name)` with `tool_registry.get(tool_name)` in `src/meta_mcp/middleware.py`.
- Add `test_get_required_scopes_from_registry` in `tests/test_coverage_completion.py` to assert registry scopes (e.g. `tool:write_file`, `filesystem:write`) and the resource path scope `resource:path:/tmp/example.txt` are included.

### Testing
- Ran `pytest -k "get_required_scopes_from_registry" tests/test_coverage_completion.py` which failed to run due to a missing dependency: `ModuleNotFoundError: No module named 'redis'`, so the new test could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966c29774e48326973de61d1aecd82c)