### PR TITLE
Disable legacy discovery auto-registration and add import-guard test

### DIFF
--- a/src/meta_mcp/discovery.py
+++ b/src/meta_mcp/discovery.py
@@ -18,10 +18,13 @@ Deprecated Components (kept for backward compatibility):
 - tool_registry singleton (replaced by registry.tool_registry)
 
 Migration Path:
-- OLD: from meta_mcp.discovery import tool_registry
-- NEW: from meta_mcp.registry import tool_registry
+- Prefer registry-backed tools: from meta_mcp.registry import tool_registry
+- Legacy fallback (manual registration): from meta_mcp.discovery import tool_registry
+  then call register_core_tools() explicitly, or set
+  META_MCP_AUTO_REGISTER_DISCOVERY_TOOLS=true to restore legacy auto-registration.
 """
 
+import os
 from dataclasses import dataclass
 from typing import List
 
@@ -363,5 +366,7 @@ def format_search_results(results) -> str:
 # Module-level singleton (DEPRECATED - use registry.tool_registry instead)
 tool_registry = ToolRegistry()
 
-# Auto-register core tools on import (DEPRECATED)
-register_core_tools()
+# Auto-register core tools on import (DEPRECATED, opt-in only)
+_AUTO_REGISTER_ENV = "META_MCP_AUTO_REGISTER_DISCOVERY_TOOLS"
+if os.getenv(_AUTO_REGISTER_ENV, "").lower() in {"1", "true", "yes", "on"}:
+    register_core_tools()

--- a/tests/integration/test_end_to_end_scenario.py
+++ b/tests/integration/test_end_to_end_scenario.py
@@ -14,7 +14,7 @@ verifying all phases work together correctly.
 import asyncio
 import pytest
 from unittest.mock import AsyncMock
-from src.meta_mcp.discovery import tool_registry
+from src.meta_mcp.discovery import register_core_tools, tool_registry
 from src.meta_mcp.registry.registry import ToolRegistry
 from src.meta_mcp.registry.models import ToolRecord
 from src.meta_mcp.leases.manager import lease_manager
@@ -25,6 +25,11 @@ from src.meta_mcp.toon.encoder import encode_output
 from src.meta_mcp.macros.batch_read import batch_read_tools
 from src.meta_mcp.macros.batch_search import batch_search_tools
 from src.meta_mcp.config import Config
+
+
+@pytest.fixture(scope="module", autouse=True)
+def register_legacy_tool_summaries():
+    register_core_tools()
 
 
 @pytest.mark.asyncio

--- a/tests/test_no_legacy_discovery_imports.py
+++ b/tests/test_no_legacy_discovery_imports.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+FORBIDDEN_PATTERNS = [
+    r"from\s+meta_mcp\.discovery\s+import\s+tool_registry",
+    r"from\s+src\.meta_mcp\.discovery\s+import\s+tool_registry",
+    r"from\s+\.discovery\s+import\s+tool_registry",
+    r"meta_mcp\.discovery\.tool_registry",
+]
+
+
+def test_no_new_discovery_tool_registry_imports():
+    src_root = Path(__file__).resolve().parents[1] / "src"
+    assert src_root.exists(), "Expected src directory to exist for import checks."
+
+    violations: list[str] = []
+    pattern = re.compile("|".join(FORBIDDEN_PATTERNS))
+
+    for path in src_root.rglob("*.py"):
+        if path.name == "discovery.py":
+            continue
+        content = path.read_text(encoding="utf-8")
+        if pattern.search(content):
+            violations.append(str(path.relative_to(src_root)))
+
+    assert not violations, (
+        "New code should not import meta_mcp.discovery.tool_registry. "
+        "Use meta_mcp.registry.tool_registry instead. "
+        f"Found in: {', '.join(sorted(violations))}"
+    )


### PR DESCRIPTION
### Motivation
- Prevent side effects from importing `meta_mcp.discovery` by stopping automatic registration of legacy tools on import. 
- Encourage new code to use the canonical `meta_mcp.registry.tool_registry` and provide a clear migration path for legacy usage. 
- Catch regressions where new source files start importing the deprecated `discovery.tool_registry` via automated checks. 

### Description
- Documented the preferred migration path and added instructions for a legacy opt-in in `src/meta_mcp/discovery.py` and added an `import os` dependency. 
- Made legacy auto-registration opt-in by gating `register_core_tools()` behind the `META_MCP_AUTO_REGISTER_DISCOVERY_TOOLS` environment variable. 
- Updated `tests/integration/test_end_to_end_scenario.py` to explicitly call `register_core_tools()` via an autouse `pytest` fixture so the integration tests remain compatible. 
- Added a new test `tests/test_no_legacy_discovery_imports.py` that fails if any new `src` code imports `meta_mcp.discovery.tool_registry`, enforcing the migration to `meta_mcp.registry.tool_registry`. 

### Testing
- Added `tests/test_no_legacy_discovery_imports.py` (static import check) but did not run the test suite in this change set. 
- Updated `tests/integration/test_end_to_end_scenario.py` to register legacy summaries explicitly so integration tests will pass when run with the new opt-in behavior. 
- No automated tests were executed as part of this PR creation step.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966c2cd31148326b7d15d41fc1b7892)