### PR TITLE
Move search formatting to registry and deprecate discovery registry

### DIFF
--- a/src/meta_mcp/discovery.py
+++ b/src/meta_mcp/discovery.py
@@ -1,367 +1,63 @@
 """
-Discovery utilities and legacy registry for backward compatibility.
+Discovery utilities and legacy compatibility shims.
 
 Module Status:
-- format_search_results(): ACTIVE - Formats search results for agent consumption
-- ToolRegistry: DEPRECATED - Use registry.registry.ToolRegistry instead
-- ToolSummary: DEPRECATED - Use ToolRecord/ToolCandidate from registry instead
-- tool_registry instance: DEPRECATED - Use registry.tool_registry instead
+- format_search_results(): MOVED to meta_mcp.registry.formatting
+- ToolRegistry/tool_registry: DEPRECATED - use meta_mcp.registry.tool_registry
 
-Active Components:
-- format_search_results(results) -> str
-  Formats tool search results for display to agents. Used by supervisor.py.
-  Accepts both legacy ToolSummary and new ToolCandidate objects.
-
-Deprecated Components (kept for backward compatibility):
-- ToolRegistry class (replaced by registry/registry.py with config/tools.yaml)
-- ToolSummary dataclass (replaced by ToolRecord/ToolCandidate)
-- tool_registry singleton (replaced by registry.tool_registry)
+Source of truth:
+- Tool definitions are loaded from config/tools.yaml via meta_mcp.registry.
 
 Migration Path:
 - OLD: from meta_mcp.discovery import tool_registry
 - NEW: from meta_mcp.registry import tool_registry
 """
 
-from dataclasses import dataclass
-from typing import List
+from warnings import warn
 
-
-@dataclass
-class ToolSummary:
-    """
-    Minimal tool metadata for discovery.
-
-    Contains only essential information to minimize context injection.
-    """
-
-    name: str
-    description: str  # First sentence only
-    category: str  # "core", "git", "search", etc.
-    sensitive: bool  # True if tool requires governance
+from .registry import tool_registry as _canonical_tool_registry
 
 
 class ToolRegistry:
     """
-    Tool registry for lazy-loading discovery.
+    Deprecated ToolRegistry shim.
 
-    Features:
-    - Minimal bootstrap set (3 tools)
-    - Simple string matching for search
-    - Metadata-only results (no schemas)
-    - Sensitivity classification
+    The canonical registry is loaded from config/tools.yaml. Use
+    meta_mcp.registry.ToolRegistry or meta_mcp.registry.tool_registry.
     """
 
-    def __init__(self):
-        """Initialize empty tool registry."""
-        self._tools: dict[str, ToolSummary] = {}
-
-    def register(
-        self,
-        name: str,
-        description: str,
-        category: str,
-        sensitive: bool = False,
-    ):
-        """
-        Register a tool in the discovery registry.
-
-        IMPORTANT: This does NOT expose the tool to tools/list.
-        Tools registered here are:
-        - Searchable via search_tools()
-        - NOT visible in tools/list until get_tool_schema() is called
-
-        This enables progressive discovery:
-        1. Tools are registered at startup (searchable metadata)
-        2. Tools remain hidden from tools/list initially
-        3. Model uses search_tools() to find relevant tools
-        4. Model calls get_tool_schema() to expose and get full schema
-        5. Tool then appears in tools/list and can be invoked
-
-        Args:
-            name: Tool name (canonical)
-            description: First sentence description only
-            category: Tool category
-            sensitive: Whether tool requires governance (write/execute operations)
-        """
-        # Extract first sentence if multiple sentences provided
-        first_sentence = description.split(".")[0].strip() + "."
-
-        self._tools[name] = ToolSummary(
-            name=name,
-            description=first_sentence,
-            category=category,
-            sensitive=sensitive,
+    def __init__(self, *args, **kwargs):
+        warn(
+            "meta_mcp.discovery.ToolRegistry is deprecated; use "
+            "meta_mcp.registry.ToolRegistry loaded from config/tools.yaml.",
+            DeprecationWarning,
+            stacklevel=2,
         )
+        self._registry = _canonical_tool_registry
 
-    def search(self, query: str) -> List[ToolSummary]:
-        """
-        Search for tools by name or description.
-
-        Uses simple string matching: name match > description match.
-        No ranking, recommendation, or prioritization beyond basic matching.
-
-        Args:
-            query: Search query string
-
-        Returns:
-            List of matching ToolSummary objects (name matches first, then description matches)
-        """
-        if not query or not query.strip():
-            return []
-
-        query_lower = query.lower().strip()
-        name_matches = []
-        description_matches = []
-
-        for tool in self._tools.values():
-            # Name match takes priority
-            if query_lower in tool.name.lower():
-                name_matches.append(tool)
-            # Description match is secondary
-            elif query_lower in tool.description.lower():
-                description_matches.append(tool)
-
-        # Return name matches first, then description matches
-        return name_matches + description_matches
-
-    def get_bootstrap_tools(self) -> List[str]:
-        """
-        Get minimal bootstrap tool set for progressive discovery.
-
-        ONLY these tools are exposed at startup:
-        - search_tools: Entry point for discovery
-        - get_tool_schema: Triggers tool exposure (progressive discovery)
-
-        All other tools (including read_file, list_directory) are:
-        1. Registered in this registry (searchable via search_tools)
-        2. NOT exposed in tools/list initially
-        3. Exposed ONLY when get_tool_schema is called
-
-        This implements true progressive discovery.
-
-        Returns:
-            List of 2 bootstrap tool names
-        """
-        return ["search_tools", "get_tool_schema"]
-
-    def get_all_summaries(self) -> List[ToolSummary]:
-        """
-        Get all registered tool summaries.
-
-        Returns:
-            List of all ToolSummary objects
-        """
-        return list(self._tools.values())
-
-    def is_registered(self, name: str) -> bool:
-        """
-        Check if tool is registered.
-
-        Args:
-            name: Tool name to check
-
-        Returns:
-            True if tool is registered, False otherwise
-        """
-        return name in self._tools
+    def __getattr__(self, name):
+        warn(
+            "meta_mcp.discovery.ToolRegistry is deprecated; use "
+            "meta_mcp.registry.ToolRegistry loaded from config/tools.yaml.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return getattr(self._registry, name)
 
 
-def register_core_tools():
-    """
-    Register all core tools with correct sensitivity flags.
+class _DeprecatedToolRegistryProxy:
+    def __init__(self, registry):
+        self._registry = registry
 
-    Sensitivity classification:
-    - NOT sensitive: read_file, list_directory (read operations)
-    - SENSITIVE: write_file, delete_file, create_directory, move_file, execute_command
-    """
-    # Read operations (NOT sensitive)
-    tool_registry.register(
-        name="read_file",
-        description="Read file contents from workspace.",
-        category="core",
-        sensitive=False,
-    )
-
-    tool_registry.register(
-        name="list_directory",
-        description="List directory contents with type indicators.",
-        category="core",
-        sensitive=False,
-    )
-
-    # Write operations (SENSITIVE)
-    tool_registry.register(
-        name="write_file",
-        description="Write content to file in workspace.",
-        category="core",
-        sensitive=True,
-    )
-
-    tool_registry.register(
-        name="delete_file",
-        description="Delete file from workspace.",
-        category="core",
-        sensitive=True,
-    )
-
-    tool_registry.register(
-        name="create_directory",
-        description="Create directory in workspace.",
-        category="core",
-        sensitive=True,
-    )
-
-    tool_registry.register(
-        name="move_file",
-        description="Move or rename file within workspace.",
-        category="core",
-        sensitive=True,
-    )
-
-    # Command execution (SENSITIVE)
-    tool_registry.register(
-        name="execute_command",
-        description="Execute shell command with timeout.",
-        category="core",
-        sensitive=True,
-    )
-
-    # Discovery tools (NOT sensitive - required for bootstrap)
-    tool_registry.register(
-        name="search_tools",
-        description="Search for available tools by name or description.",
-        category="core",
-        sensitive=False,
-    )
-
-    tool_registry.register(
-        name="get_tool_schema",
-        description="Get JSON schema for a specific tool.",
-        category="core",
-        sensitive=False,
-    )
-
-    # Git operations (SENSITIVE)
-    tool_registry.register(
-        name="git_commit",
-        description="Create a git commit with staged changes.",
-        category="git",
-        sensitive=True,
-    )
-
-    tool_registry.register(
-        name="git_push",
-        description="Push commits to remote repository.",
-        category="git",
-        sensitive=True,
-    )
-
-    tool_registry.register(
-        name="git_reset",
-        description="Reset git repository to a specific state.",
-        category="git",
-        sensitive=True,
-    )
-
-    # Admin operations (SENSITIVE)
-    tool_registry.register(
-        name="set_governance_mode",
-        description="Set the governance execution mode.",
-        category="admin",
-        sensitive=True,
-    )
-
-    tool_registry.register(
-        name="get_governance_status",
-        description="Get current governance mode and state.",
-        category="admin",
-        sensitive=False,
-    )
-
-    tool_registry.register(
-        name="revoke_all_elevations",
-        description="Revoke all active governance elevations.",
-        category="admin",
-        sensitive=True,
-    )
+    def __getattr__(self, name):
+        warn(
+            "meta_mcp.discovery.tool_registry is deprecated; use "
+            "meta_mcp.registry.tool_registry loaded from config/tools.yaml.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return getattr(self._registry, name)
 
 
-def format_search_results(results) -> str:
-    """
-    Format search results for agent consumption.
-
-    ACTIVE UTILITY: This function is NOT deprecated and is actively used by supervisor.py.
-
-    Returns ONLY:
-    - Tool name
-    - One-sentence description
-    - Sensitivity flag
-
-    Does NOT include:
-    - Arguments or schemas
-    - Examples or usage hints
-    - Recommendations or rankings
-
-    Args:
-        results: List of ToolSummary or ToolCandidate objects
-
-    Returns:
-        Formatted string with minimal metadata
-
-    Note:
-        Accepts both legacy ToolSummary and new ToolCandidate objects
-        for backward compatibility during migration.
-    """
-    if not results:
-        return "No tools found matching your query."
-
-    lines = [f"Found {len(results)} tool(s):\n"]
-
-    for tool in results:
-        # Handle both ToolSummary (old) and ToolCandidate (new)
-        if hasattr(tool, 'sensitive'):
-            # Old ToolSummary
-            sensitivity = "[SENSITIVE]" if tool.sensitive else "[SAFE]"
-            tool_name = tool.name
-            description = tool.description
-        else:
-            # New ToolCandidate
-            sensitivity = "[SAFE]" if tool.risk_level == "safe" else "[SENSITIVE]"
-            tool_name = tool.tool_id
-            description = tool.description_1line
-
-        lines.append(f"• {tool_name} {sensitivity}")
-        lines.append(f"  {description}")
-        lines.append("")  # Blank line between tools
-
-    return "\n".join(lines).strip()
-
-
-# ============================================================================
-# DEPRECATED REGISTRY INSTANCE
-# ============================================================================
-# WARNING: This module-level singleton is DEPRECATED.
-# DO NOT use this registry in new code.
-#
-# Migration:
-#   OLD: from meta_mcp.discovery import tool_registry
-#   NEW: from meta_mcp.registry import tool_registry
-#
-# The NEW registry:
-# - Loads from config/tools.yaml (static definitions)
-# - Uses ToolRecord/ToolCandidate models (richer metadata)
-# - Supports semantic search (Phase 2)
-# - Is the canonical source of truth
-#
-# This OLD registry:
-# - Uses in-memory registration (dynamic)
-# - Uses ToolSummary model (minimal metadata)
-# - Only supports keyword search
-# - Kept for backward compatibility only
-# ============================================================================
-
-# Module-level singleton (DEPRECATED - use registry.tool_registry instead)
-tool_registry = ToolRegistry()
-
-# Auto-register core tools on import (DEPRECATED)
-register_core_tools()
+# Deprecated module-level singleton proxy.
+tool_registry = _DeprecatedToolRegistryProxy(_canonical_tool_registry)

--- a/src/meta_mcp/registry/__init__.py
+++ b/src/meta_mcp/registry/__init__.py
@@ -1,5 +1,12 @@
 """Tool registry package."""
+from .formatting import format_search_results
 from .models import ServerRecord, ToolCandidate, ToolRecord
 from .registry import tool_registry
 
-__all__ = ["tool_registry", "ToolRecord", "ServerRecord", "ToolCandidate"]
+__all__ = [
+    "format_search_results",
+    "tool_registry",
+    "ToolRecord",
+    "ServerRecord",
+    "ToolCandidate",
+]

--- a/src/meta_mcp/registry/formatting.py
+++ b/src/meta_mcp/registry/formatting.py
@@ -1,0 +1,43 @@
+"""Formatting helpers for tool registry search results."""
+
+from collections.abc import Iterable
+
+from .models import ToolCandidate, ToolRecord
+
+
+def format_search_results(results: Iterable[ToolCandidate | ToolRecord]) -> str:
+    """
+    Format search results for agent consumption.
+
+    Returns ONLY:
+    - Tool name
+    - One-sentence description
+    - Sensitivity flag
+
+    Does NOT include:
+    - Arguments or schemas
+    - Examples or usage hints
+    - Recommendations or rankings
+
+    Args:
+        results: Iterable of ToolCandidate or ToolRecord objects
+
+    Returns:
+        Formatted string with minimal metadata
+    """
+    results_list = list(results)
+    if not results_list:
+        return "No tools found matching your query."
+
+    lines = [f"Found {len(results_list)} tool(s):\n"]
+
+    for tool in results_list:
+        sensitivity = "[SAFE]" if tool.risk_level == "safe" else "[SENSITIVE]"
+        tool_name = tool.tool_id
+        description = tool.description_1line
+
+        lines.append(f"• {tool_name} {sensitivity}")
+        lines.append(f"  {description}")
+        lines.append("")  # Blank line between tools
+
+    return "\n".join(lines).strip()

--- a/src/meta_mcp/registry/registry.py
+++ b/src/meta_mcp/registry/registry.py
@@ -11,7 +11,7 @@ class ToolRegistry:
     """
     Static tool registry loaded from YAML.
 
-    Replaces the dynamic discovery.ToolRegistry for Phase 1+.
+    config/tools.yaml is the single source of truth for tool definitions.
 
     Features:
     - Static tool definitions from YAML
@@ -29,7 +29,7 @@ class ToolRegistry:
     @classmethod
     def from_yaml(cls, yaml_path: str) -> "ToolRegistry":
         """
-        Load registry from YAML file.
+        Load registry from YAML file (config/tools.yaml is canonical).
 
         Args:
             yaml_path: Path to tools.yaml configuration file

--- a/src/meta_mcp/supervisor.py
+++ b/src/meta_mcp/supervisor.py
@@ -17,13 +17,12 @@ from servers.core_tools import core_server
 
 from .audit import audit_logger
 from .config import Config
-from .discovery import format_search_results
 from .governance.approval import get_approval_provider
 from .governance.artifacts import get_artifact_generator
 from .governance.policy import evaluate_policy
 from .governance.tokens import generate_token
 from .leases import lease_manager
-from .registry import tool_registry
+from .registry import format_search_results, tool_registry
 from .middleware import GovernanceMiddleware
 from .state import governance_state
 from .validation import run_all_validations
@@ -165,7 +164,7 @@ async def lifespan(app):
 
     Startup:
     1. Redis connectivity verification (graceful degradation to PERMISSION mode)
-    2. Core tools registration in discovery registry
+    2. Tool registry loaded from config/tools.yaml
     3. Workspace directory creation
     4. Compliance validations (bootstrap tools, progressive discovery)
     5. Approval provider health check
@@ -190,8 +189,7 @@ async def lifespan(app):
         # governance_state.get_mode() already handles fail-safe to PERMISSION
         # No need to crash - system will operate in PERMISSION mode
 
-    # 2. Register core tools in discovery registry
-    # (Already done via auto-registration in discovery.py on import)
+    # 2. Tool registry loaded from config/tools.yaml (single source of truth)
     all_tools = tool_registry.get_all_summaries()
     logger.info(f"Tool registry initialized with {len(all_tools)} tools")
 


### PR DESCRIPTION
### Motivation
- Centralize search-result formatting with the canonical tool registry and emphasize `config/tools.yaml` as the single source of truth. 
- Replace the legacy in-memory discovery registry with a thin compatibility shim that forwards to the YAML-backed registry and emits clear deprecation warnings.

### Description
- Moved `format_search_results()` into a new module `src/meta_mcp/registry/formatting.py` and re-exported it from `src/meta_mcp/registry/__init__.py` so callers can import `meta_mcp.registry.format_search_results`.
- Updated imports in `src/meta_mcp/supervisor.py` to use `from .registry import format_search_results, tool_registry` instead of `meta_mcp.discovery`.
- Replaced the long legacy implementation in `src/meta_mcp/discovery.py` with deprecation shims: a `ToolRegistry` wrapper and a `tool_registry` proxy that forward to `meta_mcp.registry.tool_registry` and raise `DeprecationWarning` when used.
- Updated documentation strings in `src/meta_mcp/registry/registry.py` and `src/meta_mcp/supervisor.py` to call out `config/tools.yaml` as the canonical source of tool definitions.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966c3ae0c6c83268f7326e4bd9e81e9)