### PR TITLE
FastMCP elicit: accept structured approval responses (JSON / key=value) and enforce scope validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,31 @@ Sensitive operations trigger approval flows with:
 - Scoped elevations (per-tool, per-resource, per-session)
 - Audit logging of all decisions
 
+#### FastMCP `ctx.elicit()` Response Format
+
+When using the FastMCP approval provider, clients must respond to `ctx.elicit()` with
+structured data that includes `selected_scopes` and `lease_seconds`. The server accepts
+either JSON or key-value formats:
+
+**JSON**
+```json
+{
+  "decision": "approved",
+  "selected_scopes": ["tool:write_file", "resource:path:/path/to/file"],
+  "lease_seconds": 300
+}
+```
+
+**Key-value (newline or semicolon separated)**
+```
+decision=approved
+selected_scopes=tool:write_file, resource:path:/path/to/file
+lease_seconds=300
+```
+
+Set `lease_seconds` to `0` for single-use approval. The middleware still enforces that
+all required scopes must be selected and rejects any extra scopes.
+
 ## Documentation
 
 ### Core Documentation

--- a/src/meta_mcp/governance/approval.py
+++ b/src/meta_mcp/governance/approval.py
@@ -292,33 +292,26 @@ Operation: {request.message}
 Required Permissions:
 {scope_list}
 
-Do you approve this operation? (yes/no)
+Respond with JSON or key=value pairs including decision, selected_scopes, lease_seconds.
+
+JSON example:
+{{"decision": "approved", "selected_scopes": [{", ".join([f'"{scope}"' for scope in request.required_scopes])}], "lease_seconds": 300}}
+
+Key-value example (line or semicolon separated):
+decision=approved
+selected_scopes={", ".join(request.required_scopes)}
+lease_seconds=300
+
+Use lease_seconds=0 for single-use approval.
 """
 
             # Elicit approval from user
-            response_text = await asyncio.wait_for(
+            response_payload = await asyncio.wait_for(
                 self._context.elicit(elicit_message),
                 timeout=request.timeout_seconds,
             )
 
-            # Parse simple yes/no response
-            normalized = response_text.strip().lower()
-            if normalized in {"yes", "y", "approve", "approved"}:
-                # Grant all required scopes on approval
-                return ApprovalResponse(
-                    request_id=request.request_id,
-                    decision=ApprovalDecision.APPROVED,
-                    selected_scopes=request.required_scopes,
-                    lease_seconds=300,  # Default 5 minute lease
-                    timestamp=time.time(),
-                )
-            else:
-                return ApprovalResponse(
-                    request_id=request.request_id,
-                    decision=ApprovalDecision.DENIED,
-                    selected_scopes=[],
-                    timestamp=time.time(),
-                )
+            return self._parse_approval_payload(request, response_payload)
 
         except asyncio.TimeoutError:
             return ApprovalResponse(
@@ -339,6 +332,131 @@ Do you approve this operation? (yes/no)
     def get_name(self) -> str:
         """Get provider name."""
         return "FastMCP Elicit"
+
+    @staticmethod
+    def _parse_approval_payload(
+        request: ApprovalRequest, response_payload: Any
+    ) -> ApprovalResponse:
+        payload = response_payload
+        if hasattr(response_payload, "data"):
+            payload = response_payload.data
+
+        parsed = FastMCPElicitProvider._parse_structured_response(payload)
+        if not parsed:
+            return ApprovalResponse(
+                request_id=request.request_id,
+                decision=ApprovalDecision.ERROR,
+                selected_scopes=[],
+                error_message="Invalid approval response format",
+            )
+
+        decision = FastMCPElicitProvider._parse_decision(parsed.get("decision"))
+        selected_scopes = FastMCPElicitProvider._parse_scopes(parsed.get("selected_scopes"))
+        lease_seconds = FastMCPElicitProvider._parse_lease_seconds(parsed.get("lease_seconds"))
+
+        if decision is None:
+            decision = (
+                ApprovalDecision.APPROVED
+                if selected_scopes
+                else ApprovalDecision.DENIED
+            )
+
+        return ApprovalResponse(
+            request_id=request.request_id,
+            decision=decision,
+            selected_scopes=selected_scopes,
+            lease_seconds=lease_seconds,
+            timestamp=time.time(),
+        )
+
+    @staticmethod
+    def _parse_structured_response(payload: Any) -> Dict[str, Any]:
+        if payload is None:
+            return {}
+
+        if isinstance(payload, dict):
+            return {str(key).lower(): value for key, value in payload.items()}
+
+        if isinstance(payload, str):
+            stripped = payload.strip()
+            if not stripped:
+                return {}
+            try:
+                parsed_json = json.loads(stripped)
+                if isinstance(parsed_json, dict):
+                    return {
+                        str(key).lower(): value for key, value in parsed_json.items()
+                    }
+            except json.JSONDecodeError:
+                pass
+            return FastMCPElicitProvider._parse_key_value_response(stripped)
+
+        return {}
+
+    @staticmethod
+    def _parse_key_value_response(payload: str) -> Dict[str, Any]:
+        parsed: Dict[str, Any] = {}
+        for chunk in payload.split(";"):
+            for line in chunk.splitlines():
+                if not line.strip():
+                    continue
+                if "=" in line:
+                    key, value = line.split("=", 1)
+                elif ":" in line:
+                    key, value = line.split(":", 1)
+                else:
+                    continue
+                parsed[key.strip().lower()] = value.strip()
+        return parsed
+
+    @staticmethod
+    def _parse_decision(raw_value: Any) -> Optional[ApprovalDecision]:
+        if raw_value is None:
+            return None
+        normalized = str(raw_value).strip().lower()
+        if normalized in {"approved", "approve", "yes", "y"}:
+            return ApprovalDecision.APPROVED
+        if normalized in {"denied", "deny", "no", "n"}:
+            return ApprovalDecision.DENIED
+        if normalized == "timeout":
+            return ApprovalDecision.TIMEOUT
+        if normalized == "error":
+            return ApprovalDecision.ERROR
+        return None
+
+    @staticmethod
+    def _parse_scopes(raw_value: Any) -> List[str]:
+        if raw_value is None:
+            return []
+        if isinstance(raw_value, list):
+            return [str(scope).strip() for scope in raw_value if str(scope).strip()]
+        if isinstance(raw_value, str):
+            stripped = raw_value.strip()
+            if not stripped:
+                return []
+            if stripped.startswith("["):
+                try:
+                    parsed_json = json.loads(stripped)
+                    if isinstance(parsed_json, list):
+                        return [
+                            str(scope).strip()
+                            for scope in parsed_json
+                            if str(scope).strip()
+                        ]
+                except json.JSONDecodeError:
+                    pass
+            return [scope.strip() for scope in stripped.split(",") if scope.strip()]
+        return [str(raw_value).strip()] if str(raw_value).strip() else []
+
+    @staticmethod
+    def _parse_lease_seconds(raw_value: Any) -> int:
+        if raw_value is None:
+            return 0
+        try:
+            lease_seconds = int(float(raw_value))
+        except (TypeError, ValueError):
+            return 0
+        return max(0, lease_seconds)
 
 
 class SystemdFallbackProvider(ApprovalProvider):

--- a/src/meta_mcp/middleware.py
+++ b/src/meta_mcp/middleware.py
@@ -329,42 +329,6 @@ class GovernanceMiddleware(Middleware):
 
         return "\n".join(lines)
 
-    @staticmethod
-    def _parse_approval_response(response: str) -> bool:
-        """
-        Parse approval response from user with strict word boundary matching.
-
-        Args:
-            response: User response string
-
-        Returns:
-            True if approved, False if denied
-
-        Security:
-            Uses word boundary matching to prevent substring attacks
-            (e.g., "yokay" will NOT match "ok", only standalone "ok" matches)
-        """
-        if not response:
-            return False
-
-        normalized = response.strip().lower()
-
-        # Approval indicators (exact word matches only)
-        approval_indicators = {"approve", "yes", "accept", "ok", "allow", "y"}
-
-        # Split response into words (whitespace-separated tokens)
-        words = normalized.split()
-
-        # Check if any word exactly matches an approval indicator
-        for word in words:
-            # Remove common punctuation from word boundaries
-            cleaned_word = word.strip(".,!?;:'\"")
-            if cleaned_word in approval_indicators:
-                return True
-
-        # Denial is default (fail-safe)
-        return False
-
     async def _elicit_approval(
         self, ctx: Context, tool_name: str, arguments: Dict[str, Any]
     ) -> tuple[bool, int, List[str]]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 """Pytest fixtures and test utilities for Meta MCP Server test suite."""
 
 import asyncio
+import json
 import tempfile
 from pathlib import Path
 from typing import Any, Dict, Optional
@@ -178,7 +179,16 @@ def mock_elicit_approve():
     async def _approve(*args, **kwargs):
         # Return mock AcceptedElicitation with approval response
         result = MagicMock()
-        result.data = "approve"
+        result.data = json.dumps(
+            {
+                "decision": "approved",
+                "selected_scopes": [
+                    "tool:write_file",
+                    "resource:path:test.txt",
+                ],
+                "lease_seconds": 300,
+            }
+        )
         return result
 
     return AsyncMock(side_effect=_approve)
@@ -196,7 +206,13 @@ def mock_elicit_deny():
     async def _deny(*args, **kwargs):
         # Return mock AcceptedElicitation with denial response
         result = MagicMock()
-        result.data = "deny"
+        result.data = json.dumps(
+            {
+                "decision": "denied",
+                "selected_scopes": [],
+                "lease_seconds": 0,
+            }
+        )
         return result
 
     return AsyncMock(side_effect=_deny)


### PR DESCRIPTION
### Motivation
- Replace fragile free-form yes/no parsing with a structured response format so clients can specify `selected_scopes` and `lease_seconds` reliably. 
- Keep server-side security guarantees: middleware must still require all required scopes and reject invalid extra scopes. 
- Remove legacy unneeded free-form parser from middleware and provide parsing helpers in the approval provider for maintainability. 
- Document the `ctx.elicit()` response format for client implementers.

### Description
- `src/meta_mcp/governance/approval.py`: `FastMCPElicitProvider.request_approval()` now asks clients to return structured data (JSON or key/value pairs) and routes the response to new parsing helpers; added `_parse_approval_payload`, `_parse_structured_response`, `_parse_key_value_response`, `_parse_decision`, `_parse_scopes`, and `_parse_lease_seconds` to normalize responses into `ApprovalResponse` objects. 
- `src/meta_mcp/middleware.py`: Removed the old free-form `_parse_approval_response()` implementation; middleware continues to validate `ApprovalResponse.selected_scopes` and `lease_seconds` unchanged (server-side enforcement remains intact). 
- `tests/conftest.py`: Updated `mock_elicit_approve` and `mock_elicit_deny` fixtures to return structured JSON in `result.data` to exercise the new parsing path. 
- `tests/test_elicitation.py`: Replaced many free-form approval parsing tests with new unit tests that exercise JSON and key/value parsing and an invalid-response case, and updated the malformed-response test to reflect missing fields handling. 
- `README.md`: Added a section documenting the expected `ctx.elicit()` response formats with JSON and key/value examples and guidance for `lease_seconds` semantics.

### Testing
- No automated tests were executed as part of this change (no `pytest` run in this rollout).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966c435d1b08326b66dc38a638109cf)