### PR TITLE
Use registry metadata for governance sensitivity and require registry scopes

### DIFF
--- a/tests/test_middleware_registry_controls.py
+++ b/tests/test_middleware_registry_controls.py
@@ -1,0 +1,57 @@
+"""Tests for middleware registry-driven sensitivity and scopes."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from src.meta_mcp.middleware import GovernanceMiddleware
+from src.meta_mcp.registry.models import ToolRecord
+from src.meta_mcp.registry.registry import ToolRegistry
+
+
+@pytest.mark.asyncio
+async def test_read_only_blocks_registry_sensitive_tool(
+    governance_in_read_only, mock_fastmcp_context, lease_for_tool, monkeypatch
+):
+    """READ_ONLY mode should block tools marked sensitive in the registry."""
+    registry = ToolRegistry()
+    registry.add(
+        ToolRecord(
+            tool_id="custom_sensitive",
+            server_id="custom",
+            description_1line="Custom sensitive tool.",
+            description_full="Custom sensitive tool that should be gated.",
+            tags=["custom"],
+            risk_level="sensitive",
+            requires_permission=False,
+            required_scopes=["tool:custom_sensitive"],
+        )
+    )
+
+    monkeypatch.setattr("src.meta_mcp.middleware.tool_registry", registry)
+
+    await lease_for_tool("custom_sensitive")
+
+    middleware = GovernanceMiddleware()
+    mock_fastmcp_context.request_context.tool_name = "custom_sensitive"
+    mock_fastmcp_context.request_context.arguments = {}
+
+    call_next = AsyncMock()
+
+    with pytest.raises(ToolError) as exc_info:
+        await middleware.on_call_tool(mock_fastmcp_context, call_next)
+
+    assert "READ_ONLY" in str(exc_info.value)
+    call_next.assert_not_called()
+
+
+def test_required_scopes_include_yaml_scopes():
+    """Required scopes should include registry-defined scopes from YAML."""
+    scopes = GovernanceMiddleware._get_required_scopes(
+        "write_file", {"path": "example.txt"}
+    )
+
+    assert "tool:write_file" in scopes
+    assert "filesystem:write" in scopes
+    assert "resource:path:example.txt" in scopes


### PR DESCRIPTION
### Motivation

- Remove brittle hardcoded sensitivity list and rely on canonical registry metadata to decide which tools are gated. 
- Ensure required permission scopes come from the registry (YAML) and fail loudly if registry records are missing or malformed. 
- Centralize sensitivity logic to keep `on_call_tool()` clearer and make behavior consistent with `ToolRecord` fields.

### Description

- Replaced hardcoded `SENSITIVE_TOOLS` with a registry-driven helper `GovernanceMiddleware._is_sensitive(tool_name)` that uses `tool_registry.get(...)` and raises `ToolError` for unknown tools in `src/meta_mcp/middleware.py`.
- Replaced `tool_registry.get_tool(...)` fallback behavior with `tool_registry.get(...)` and changed `_get_required_scopes()` to raise `ToolError` if the tool is not registered or lacks `required_scopes` instead of silently generating fallback scopes.
- Added explicit exception handling to propagate `ToolError` from scope lookup while preserving the original fail-safe behavior for other errors during elicitation.
- Added new test file `tests/test_middleware_registry_controls.py` verifying that registry-defined `risk_level` gates READ_ONLY behavior and that `_get_required_scopes()` includes YAML-defined scopes (including resource-scoped additions).

### Testing

- Added unit tests in `tests/test_middleware_registry_controls.py` exercising `GovernanceMiddleware` registry-driven gating and scope resolution.
- Ran `pytest -q tests/test_middleware_registry_controls.py`; test execution failed due to missing runtime dependency: `ModuleNotFoundError: No module named 'redis'` in the test environment, so tests could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966c4d54ba0832692acb4927bdbd095)