### PR TITLE
Add audit log rotation, retention cleanup, and correlation fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,15 @@ pytest --cov=src/meta_mcp --cov-report=html
 2. Ensure Redis is secured (password, network isolation)
 3. Set governance mode to PERMISSION or READ_ONLY
 4. Review audit logs regularly
-5. Keep workspace root permissions restricted
+5. Configure audit log retention/rotation to meet compliance needs
+6. Keep workspace root permissions restricted
+
+### Audit log retention and rotation
+- Audit logs are written in JSON Lines format to `AUDIT_LOG_PATH` (default: `./audit.jsonl`).
+- Logs rotate when they exceed `AUDIT_ROTATION_BYTES` (default: 10 MB). Rotated files are
+  stored alongside the active log with a timestamp suffix (e.g., `audit.jsonl.20240131120000`).
+- Logs older than `AUDIT_RETENTION_DAYS` (default: 30) are removed during scheduled cleanup
+  checks inside the audit logger.
 
 ## License
 

--- a/tests/test_audit_retention.py
+++ b/tests/test_audit_retention.py
@@ -1,0 +1,41 @@
+"""Tests for audit log rotation and retention cleanup."""
+
+from datetime import datetime, timedelta, timezone
+
+from src.meta_mcp import audit as audit_module
+from src.meta_mcp.audit import AuditEvent, AuditLogger
+
+
+def test_audit_log_rotation_and_cleanup(tmp_path, monkeypatch):
+    """Ensure audit logs rotate by size and cleanup respects retention days."""
+    log_file = tmp_path / "audit.jsonl"
+    rotation_bytes = 50
+    retention_days = 1
+
+    monkeypatch.setattr(audit_module, "AUDIT_ROTATION_BYTES", rotation_bytes)
+    monkeypatch.setattr(audit_module, "AUDIT_RETENTION_DAYS", retention_days)
+
+    logger = AuditLogger(str(log_file))
+
+    # Seed log file with data to trigger rotation on next write.
+    log_file.write_text("x" * (rotation_bytes + 1))
+    logger.log(
+        AuditEvent.TOOL_INVOKED,
+        tool_name="write_file",
+        arguments={"path": "/tmp/example.txt"},
+        session_id="session-rotate",
+    )
+
+    rotated_files = list(tmp_path.glob("audit.jsonl.*"))
+    assert rotated_files, "Expected rotated audit log file to be created."
+    assert log_file.exists(), "Expected new audit log file after rotation."
+
+    # Create an old rotated file for cleanup
+    old_file = tmp_path / "audit.jsonl.20000101000000"
+    old_file.write_text("old log")
+    old_mtime = datetime.now(timezone.utc) - timedelta(days=retention_days + 1)
+    old_timestamp = old_mtime.timestamp()
+    old_file.utime((old_timestamp, old_timestamp))
+
+    logger._cleanup_old_logs()
+    assert not old_file.exists(), "Expected old audit log file to be cleaned up."


### PR DESCRIPTION
### Motivation
- Prevent unbounded audit log growth by adding configurable rotation and retention behavior.
- Ensure every audit record carries correlation fields (`session_id`, `request_id`) for traceability.
- Document retention/rotation options for operators so logs meet compliance and ops needs.

### Description
- Add `AUDIT_ROTATION_BYTES` and make `AUDIT_RETENTION_DAYS` configurable via environment variables, and wire them into `AuditLogger` initialization. 
- Implement size-based rotation (`_rotate_if_needed`) that renames the active log with a timestamp suffix and a retention cleanup (`_cleanup_old_logs` / `_maybe_cleanup`) that removes log files older than the retention window.
- Include `session_id` and `request_id` as top-level correlation fields in every call to `AuditLogger.log` and accept them as explicit parameters.
- Update `README.md` with a short ops section describing `AUDIT_LOG_PATH`, `AUDIT_ROTATION_BYTES`, and `AUDIT_RETENTION_DAYS` behavior, and add `tests/test_audit_retention.py` to exercise rotation and cleanup behavior.

### Testing
- Ran `pytest tests/test_audit_retention.py` which attempted to execute the new retention/rotation test but failed with `ModuleNotFoundError: No module named 'redis'` in the test environment, so the test could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966c4a11c4883268587e7a6bb7e57a5)