### PR TITLE
Standardize tools.yaml path usage in scripts and benchmarks

### DIFF
--- a/benchmarks/run_baseline_benchmark.py
+++ b/benchmarks/run_baseline_benchmark.py
@@ -15,14 +15,14 @@ project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root / "src"))
 
 # Now import from the project
-from meta_mcp.registry.registry import ToolRegistry
+from meta_mcp.registry.registry import ToolRegistry, DEFAULT_TOOLS_YAML_PATH
 from meta_mcp.retrieval.search import SemanticSearch
 
 
 def benchmark_registry_loading() -> dict:
     """Benchmark registry loading time."""
     start = time.perf_counter()
-    registry = ToolRegistry.from_yaml("config/tools.yaml")
+    registry = ToolRegistry.from_yaml(DEFAULT_TOOLS_YAML_PATH)
     elapsed = time.perf_counter() - start
 
     return {
@@ -34,7 +34,7 @@ def benchmark_registry_loading() -> dict:
 
 def benchmark_search_latency(iterations: int = 100) -> dict:
     """Benchmark search operation latency."""
-    registry = ToolRegistry.from_yaml("config/tools.yaml")
+    registry = ToolRegistry.from_yaml(DEFAULT_TOOLS_YAML_PATH)
     searcher = SemanticSearch(registry)
 
     # Warm up
@@ -71,7 +71,7 @@ def benchmark_search_latency(iterations: int = 100) -> dict:
 
 def benchmark_index_building() -> dict:
     """Benchmark embedding index building time."""
-    registry = ToolRegistry.from_yaml("config/tools.yaml")
+    registry = ToolRegistry.from_yaml(DEFAULT_TOOLS_YAML_PATH)
     searcher = SemanticSearch(registry)
 
     start = time.perf_counter()
@@ -87,7 +87,7 @@ def benchmark_index_building() -> dict:
 
 def benchmark_tool_retrieval(iterations: int = 1000) -> dict:
     """Benchmark individual tool retrieval."""
-    registry = ToolRegistry.from_yaml("config/tools.yaml")
+    registry = ToolRegistry.from_yaml(DEFAULT_TOOLS_YAML_PATH)
 
     # Get a sample tool ID
     tools = registry.get_all_summaries()

--- a/benchmarks/run_invariant_validation.py
+++ b/benchmarks/run_invariant_validation.py
@@ -14,7 +14,7 @@ project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root / "src"))
 
 # Now import from the project
-from meta_mcp.registry.registry import ToolRegistry
+from meta_mcp.registry.registry import ToolRegistry, DEFAULT_TOOLS_YAML_PATH
 from meta_mcp.retrieval.search import SemanticSearch
 
 
@@ -90,7 +90,7 @@ def validate_registry_invariants(validator: InvariantValidator):
     print("Validating registry invariants...")
 
     try:
-        registry = ToolRegistry.from_yaml("config/tools.yaml")
+        registry = ToolRegistry.from_yaml(DEFAULT_TOOLS_YAML_PATH)
     except Exception as e:
         validator.check(False, f"Failed to load registry: {e}")
         return
@@ -148,7 +148,7 @@ def validate_search_invariants(validator: InvariantValidator):
     """Validate semantic search invariants."""
     print("Validating search invariants...")
 
-    registry = ToolRegistry.from_yaml("config/tools.yaml")
+    registry = ToolRegistry.from_yaml(DEFAULT_TOOLS_YAML_PATH)
     searcher = SemanticSearch(registry)
 
     # Check: Index builds successfully
@@ -195,7 +195,7 @@ def validate_embedding_invariants(validator: InvariantValidator):
     """Validate embedding invariants."""
     print("Validating embedding invariants...")
 
-    registry = ToolRegistry.from_yaml("config/tools.yaml")
+    registry = ToolRegistry.from_yaml(DEFAULT_TOOLS_YAML_PATH)
     searcher = SemanticSearch(registry)
     searcher._build_index()
 
@@ -238,7 +238,7 @@ def validate_security_properties(validator: InvariantValidator):
     """Validate security-related invariants."""
     print("Validating security properties...")
 
-    registry = ToolRegistry.from_yaml("config/tools.yaml")
+    registry = ToolRegistry.from_yaml(DEFAULT_TOOLS_YAML_PATH)
     searcher = SemanticSearch(registry)
 
     # Check: Search results don't leak schemas

--- a/benchmarks/run_load_tests.py
+++ b/benchmarks/run_load_tests.py
@@ -22,7 +22,7 @@ project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root / "src"))
 
 # Now import from the project
-from meta_mcp.registry.registry import ToolRegistry
+from meta_mcp.registry.registry import ToolRegistry, DEFAULT_TOOLS_YAML_PATH
 from meta_mcp.retrieval.search import SemanticSearch
 
 
@@ -30,7 +30,7 @@ class LoadTester:
     """Run load tests on the system."""
 
     def __init__(self):
-        self.registry = ToolRegistry.from_yaml("config/tools.yaml")
+        self.registry = ToolRegistry.from_yaml(DEFAULT_TOOLS_YAML_PATH)
         self.searcher = SemanticSearch(self.registry)
         self.searcher._build_index()
         self.tools = self.registry.get_all_summaries()

--- a/benchmarks/run_optimized_benchmark.py
+++ b/benchmarks/run_optimized_benchmark.py
@@ -15,13 +15,13 @@ project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root / "src"))
 
 # Now import from the project
-from meta_mcp.registry.registry import ToolRegistry
+from meta_mcp.registry.registry import ToolRegistry, DEFAULT_TOOLS_YAML_PATH
 from meta_mcp.retrieval.search import SemanticSearch
 
 
 def benchmark_cached_searches(iterations: int = 100) -> dict:
     """Benchmark search with hot cache."""
-    registry = ToolRegistry.from_yaml("config/tools.yaml")
+    registry = ToolRegistry.from_yaml(DEFAULT_TOOLS_YAML_PATH)
     searcher = SemanticSearch(registry)
 
     # Build index once
@@ -50,7 +50,7 @@ def benchmark_cached_searches(iterations: int = 100) -> dict:
 
 def benchmark_embedding_reuse() -> dict:
     """Benchmark embedding cache hit rate."""
-    registry = ToolRegistry.from_yaml("config/tools.yaml")
+    registry = ToolRegistry.from_yaml(DEFAULT_TOOLS_YAML_PATH)
     searcher = SemanticSearch(registry)
 
     # Build index (populates cache)
@@ -83,7 +83,7 @@ def benchmark_embedding_reuse() -> dict:
 
 def benchmark_batch_vs_individual() -> dict:
     """Compare batch operations vs individual operations."""
-    registry = ToolRegistry.from_yaml("config/tools.yaml")
+    registry = ToolRegistry.from_yaml(DEFAULT_TOOLS_YAML_PATH)
     tools = registry.get_all_summaries()
 
     if len(tools) < 5:
@@ -118,7 +118,7 @@ def benchmark_memory_footprint() -> dict:
     """Estimate memory footprint of embeddings and cache."""
     import sys
 
-    registry = ToolRegistry.from_yaml("config/tools.yaml")
+    registry = ToolRegistry.from_yaml(DEFAULT_TOOLS_YAML_PATH)
     searcher = SemanticSearch(registry)
     searcher._build_index()
 

--- a/scripts/benchmark_baseline.py
+++ b/scripts/benchmark_baseline.py
@@ -17,14 +17,14 @@ from pathlib import Path
 # Add src to path
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
-from src.meta_mcp.registry.registry import ToolRegistry
+from src.meta_mcp.registry.registry import ToolRegistry, DEFAULT_TOOLS_YAML_PATH
 from src.meta_mcp.retrieval.search import SemanticSearch
 
 
 def benchmark_registry_loading() -> dict:
     """Benchmark registry loading time."""
     start = time.perf_counter()
-    registry = ToolRegistry.from_yaml("config/tools.yaml")
+    registry = ToolRegistry.from_yaml(DEFAULT_TOOLS_YAML_PATH)
     elapsed = time.perf_counter() - start
 
     return {
@@ -36,7 +36,7 @@ def benchmark_registry_loading() -> dict:
 
 def benchmark_search_latency(iterations: int = 100) -> dict:
     """Benchmark search operation latency."""
-    registry = ToolRegistry.from_yaml("config/tools.yaml")
+    registry = ToolRegistry.from_yaml(DEFAULT_TOOLS_YAML_PATH)
     searcher = SemanticSearch(registry)
 
     # Warm up
@@ -73,7 +73,7 @@ def benchmark_search_latency(iterations: int = 100) -> dict:
 
 def benchmark_index_building() -> dict:
     """Benchmark embedding index building time."""
-    registry = ToolRegistry.from_yaml("config/tools.yaml")
+    registry = ToolRegistry.from_yaml(DEFAULT_TOOLS_YAML_PATH)
     searcher = SemanticSearch(registry)
 
     start = time.perf_counter()
@@ -89,7 +89,7 @@ def benchmark_index_building() -> dict:
 
 def benchmark_tool_retrieval(iterations: int = 1000) -> dict:
     """Benchmark individual tool retrieval."""
-    registry = ToolRegistry.from_yaml("config/tools.yaml")
+    registry = ToolRegistry.from_yaml(DEFAULT_TOOLS_YAML_PATH)
 
     # Get a sample tool ID
     tools = registry.get_all_summaries()

--- a/scripts/benchmark_optimized.py
+++ b/scripts/benchmark_optimized.py
@@ -17,13 +17,13 @@ from pathlib import Path
 # Add src to path
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
-from src.meta_mcp.registry.registry import ToolRegistry
+from src.meta_mcp.registry.registry import ToolRegistry, DEFAULT_TOOLS_YAML_PATH
 from src.meta_mcp.retrieval.search import SemanticSearch
 
 
 def benchmark_cached_searches(iterations: int = 100) -> dict:
     """Benchmark search with hot cache."""
-    registry = ToolRegistry.from_yaml("config/tools.yaml")
+    registry = ToolRegistry.from_yaml(DEFAULT_TOOLS_YAML_PATH)
     searcher = SemanticSearch(registry)
 
     # Build index once
@@ -52,7 +52,7 @@ def benchmark_cached_searches(iterations: int = 100) -> dict:
 
 def benchmark_embedding_reuse() -> dict:
     """Benchmark embedding cache hit rate."""
-    registry = ToolRegistry.from_yaml("config/tools.yaml")
+    registry = ToolRegistry.from_yaml(DEFAULT_TOOLS_YAML_PATH)
     searcher = SemanticSearch(registry)
 
     # Build index (populates cache)
@@ -85,7 +85,7 @@ def benchmark_embedding_reuse() -> dict:
 
 def benchmark_batch_vs_individual() -> dict:
     """Compare batch operations vs individual operations."""
-    registry = ToolRegistry.from_yaml("config/tools.yaml")
+    registry = ToolRegistry.from_yaml(DEFAULT_TOOLS_YAML_PATH)
     tools = registry.get_all_summaries()
 
     if len(tools) < 5:
@@ -120,7 +120,7 @@ def benchmark_memory_footprint() -> dict:
     """Estimate memory footprint of embeddings and cache."""
     import sys
 
-    registry = ToolRegistry.from_yaml("config/tools.yaml")
+    registry = ToolRegistry.from_yaml(DEFAULT_TOOLS_YAML_PATH)
     searcher = SemanticSearch(registry)
     searcher._build_index()
 

--- a/scripts/validate_invariants.py
+++ b/scripts/validate_invariants.py
@@ -17,7 +17,7 @@ from typing import List, Tuple
 # Add src to path
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
-from src.meta_mcp.registry.registry import ToolRegistry
+from src.meta_mcp.registry.registry import ToolRegistry, DEFAULT_TOOLS_YAML_PATH
 from src.meta_mcp.retrieval.search import SemanticSearch
 
 
@@ -93,7 +93,7 @@ def validate_registry_invariants(validator: InvariantValidator):
     print("Validating registry invariants...")
 
     try:
-        registry = ToolRegistry.from_yaml("config/tools.yaml")
+        registry = ToolRegistry.from_yaml(DEFAULT_TOOLS_YAML_PATH)
     except Exception as e:
         validator.check(False, f"Failed to load registry: {e}")
         return
@@ -151,7 +151,7 @@ def validate_search_invariants(validator: InvariantValidator):
     """Validate semantic search invariants."""
     print("Validating search invariants...")
 
-    registry = ToolRegistry.from_yaml("config/tools.yaml")
+    registry = ToolRegistry.from_yaml(DEFAULT_TOOLS_YAML_PATH)
     searcher = SemanticSearch(registry)
 
     # Check: Index builds successfully
@@ -198,7 +198,7 @@ def validate_embedding_invariants(validator: InvariantValidator):
     """Validate embedding invariants."""
     print("Validating embedding invariants...")
 
-    registry = ToolRegistry.from_yaml("config/tools.yaml")
+    registry = ToolRegistry.from_yaml(DEFAULT_TOOLS_YAML_PATH)
     searcher = SemanticSearch(registry)
     searcher._build_index()
 
@@ -241,7 +241,7 @@ def validate_security_properties(validator: InvariantValidator):
     """Validate security-related invariants."""
     print("Validating security properties...")
 
-    registry = ToolRegistry.from_yaml("config/tools.yaml")
+    registry = ToolRegistry.from_yaml(DEFAULT_TOOLS_YAML_PATH)
     searcher = SemanticSearch(registry)
 
     # Check: Search results don't leak schemas

--- a/src/meta_mcp/registry/registry.py
+++ b/src/meta_mcp/registry/registry.py
@@ -204,7 +204,7 @@ class ToolRegistry:
 
 
 # Singleton instance with absolute path
-_default_tools_path = os.getenv("TOOLS_YAML_PATH") or str(
+DEFAULT_TOOLS_YAML_PATH = os.getenv("TOOLS_YAML_PATH") or str(
     Path(__file__).parent.parent.parent / "config" / "tools.yaml"
 )
-tool_registry = ToolRegistry.from_yaml(_default_tools_path)
+tool_registry = ToolRegistry.from_yaml(DEFAULT_TOOLS_YAML_PATH)


### PR DESCRIPTION
### Motivation
- Multiple scripts and benchmarks were using a hard-coded `config/tools.yaml` path, causing duplicated logic and potential inconsistencies.
- The runtime registry already determines a default path from the environment (`TOOLS_YAML_PATH`) or the project `config/tools.yaml`.
- Aligning callers to use a single source of truth reduces mismatch risk and makes it easier to override the path via environment.

### Description
- Expose a shared `DEFAULT_TOOLS_YAML_PATH` constant in `src/meta_mcp/registry/registry.py` and use it to initialize the runtime `tool_registry` instead of a local variable. 
- Update imports in scripts and benchmarks to pull `DEFAULT_TOOLS_YAML_PATH` from `meta_mcp.registry.registry` or `src.meta_mcp.registry.registry` as appropriate. 
- Replace hard-coded calls like `ToolRegistry.from_yaml("config/tools.yaml")` with `ToolRegistry.from_yaml(DEFAULT_TOOLS_YAML_PATH)` across the benchmark, load-test, and validation scripts. 
- Changes touch `src/meta_mcp/registry/registry.py`, multiple files under `scripts/` and `benchmarks/`, and `benchmarks/run_*` utilities to centralize the path logic.

### Testing
- No automated tests were executed as part of this change. 
- All modifications are straightforward refactors of import/path usage and should be covered by existing unit/benchmark runs when invoked; please run the project's test/benchmark suite to validate runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966c8a2f9748326b241c3f886cbe3d2)