### PR TITLE
Use supervisor entrypoint for server startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ export DEFAULT_GOVERNANCE_MODE="permission"
 
 ```bash
 # Start the server
-python main.py
+meta-mcp-server
 ```
 
 The server will start on `http://localhost:8001` by default.

--- a/main.py
+++ b/main.py
@@ -1,5 +1,8 @@
+from meta_mcp.supervisor import main as supervisor_main
+
+
 def main():
-    print("Hello from meta-mcp-server!")
+    supervisor_main()
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,9 @@ dependencies = [
     "uvicorn>=0.30",
 ]
 
+[project.scripts]
+meta-mcp-server = "meta_mcp.supervisor:main"
+
 [project.optional-dependencies]
 dev = [
     "pytest>=8.0",


### PR DESCRIPTION
### Motivation

- Ensure the top-level startup uses the real MetaSupervisor entrypoint so startup logging and configuration from `meta_mcp.supervisor` are used instead of a placeholder print.
- Provide a canonical CLI entrypoint for installed packages so users can start the server consistently.
- Update documentation to point developers to the canonical launch method.

### Description

- Replaced the placeholder in `main.py` to import and call `meta_mcp.supervisor.main()` so running `python main.py` delegates to the supervisor entrypoint. 
- Added a console-script entry in `pyproject.toml` with `meta-mcp-server = "meta_mcp.supervisor:main"` so the package exposes a canonical `meta-mcp-server` CLI. 
- Updated `README.md` startup instructions to reference the canonical `meta-mcp-server` command. 
- This makes the server start with the `MetaSupervisor` logging/handlers defined in `src/meta_mcp/supervisor.py` (Loguru configuration and `mcp.run(...)`).

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966c520aeb083268889544b0e4d0ec5)