### PR TITLE
Use tool registry `get` for required scopes

### DIFF
--- a/src/meta_mcp/middleware.py
+++ b/src/meta_mcp/middleware.py
@@ -247,7 +247,7 @@ class GovernanceMiddleware(Middleware):
             List of required permission scopes
         """
         # Start with base scopes from registry
-        tool_record = tool_registry.get_tool(tool_name)
+        tool_record = tool_registry.get(tool_name)
         if tool_record and tool_record.required_scopes:
             base_scopes = tool_record.required_scopes.copy()
         else:


### PR DESCRIPTION
### Motivation
- Align the middleware with the registry API by using the registry's `get` accessor so required-scopes lookup uses the actual `ToolRegistry` interface and avoids relying on a non-existing `get_tool` method while preserving existing scope behavior.

### Description
- Replace `tool_registry.get_tool(tool_name)` with `tool_registry.get(tool_name)` in `GovernanceMiddleware._get_required_scopes` so the `ToolRecord` (and its `required_scopes`) is retrieved via `ToolRegistry.get`, keeping the existing fallback and resource-specific scope augmentation unchanged.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966c822263483268a516689fdc576ea)