### PR TITLE
Defer lease consumption until tool success

### DIFF
--- a/src/meta_mcp/middleware.py
+++ b/src/meta_mcp/middleware.py
@@ -650,6 +650,8 @@ class GovernanceMiddleware(Middleware):
         # CRITICAL: Skip lease checks if ENABLE_LEASE_MANAGEMENT is False
         bootstrap_tools = {"search_tools", "get_tool_schema"}
 
+        client_id: Optional[str] = None
+        lease_required = False
         if Config.ENABLE_LEASE_MANAGEMENT and tool_name not in bootstrap_tools:
             # Extract client_id from FastMCP session context
             # In FastMCP/MCP protocol, session_id is the stable client connection identifier
@@ -693,22 +695,27 @@ class GovernanceMiddleware(Middleware):
                     f"(client: {client_id})"
                 )
 
-            # Consume lease (decrement calls_remaining)
-            consumed_lease = await lease_manager.consume(client_id, tool_name)
-            if consumed_lease is None:
-                logger.warning(
-                    f"Failed to consume lease for {tool_name} "
-                    f"(client: {client_id}, session: {session_id})"
-                )
-                raise ToolError(
-                    f"Lease exhausted for tool '{tool_name}'. "
-                    f"Please request a new lease via get_tool_schema('{tool_name}')."
-                )
+            lease_required = True
 
-            logger.info(
-                f"Lease consumed for {tool_name} "
-                f"(client: {client_id}, remaining={consumed_lease.calls_remaining})"
-            )
+        async def _call_tool() -> Any:
+            result = await call_next()
+            if lease_required and client_id is not None:
+                consumed_lease = await lease_manager.consume(client_id, tool_name)
+                if consumed_lease is None:
+                    logger.warning(
+                        f"Failed to consume lease for {tool_name} "
+                        f"(client: {client_id}, session: {session_id})"
+                    )
+                    raise ToolError(
+                        f"Lease exhausted for tool '{tool_name}'. "
+                        f"Please request a new lease via get_tool_schema('{tool_name}')."
+                    )
+
+                logger.info(
+                    f"Lease consumed for {tool_name} "
+                    f"(client: {client_id}, remaining={consumed_lease.calls_remaining})"
+                )
+            return self._apply_toon_encoding(result)
 
         # Get current governance mode
         mode = await governance_state.get_mode()
@@ -731,14 +738,12 @@ class GovernanceMiddleware(Middleware):
                 arguments=arguments,
                 session_id=session_id,
             )
-            result = await call_next()
-            return self._apply_toon_encoding(result)
+            return await _call_tool()
 
         # Path 2: Non-sensitive tools - pass through
         if tool_name not in SENSITIVE_TOOLS:
             logger.debug(f"Non-sensitive tool {tool_name}, passing through")
-            result = await call_next()
-            return self._apply_toon_encoding(result)
+            return await _call_tool()
 
         # Path 3: READ_ONLY mode - block sensitive operations
         if mode == ExecutionMode.READ_ONLY:
@@ -773,8 +778,7 @@ class GovernanceMiddleware(Middleware):
                     context_key=context_key,
                     session_id=session_id,
                 )
-                result = await call_next()
-                return self._apply_toon_encoding(result)
+                return await _call_tool()
 
             # No elevation, elicit approval
             logger.info(
@@ -804,8 +808,7 @@ class GovernanceMiddleware(Middleware):
                     )
 
                 # Execute tool
-                result = await call_next()
-                return self._apply_toon_encoding(result)
+                return await _call_tool()
             else:
                 # Denied - audit already logged in _elicit_approval
                 logger.warning(f"Approval denied for {tool_name} (session: {session_id})")


### PR DESCRIPTION
### Motivation
- Prevent leases from being consumed when a tool invocation fails so client quotas are not decremented on errors.
- Ensure lease consumption and TOON encoding are applied consistently after a successful `call_next()` invocation.
- Centralize post-call behavior to make error handling and lease refunds (if needed later) easier to implement.

### Description
- Introduce local `client_id` and `lease_required` variables and stop calling `lease_manager.consume` before execution, while keeping pre-checks via `lease_manager.validate` and token verification.
- Add an async helper `_call_tool()` that runs `call_next()`, then consumes the lease via `lease_manager.consume` (if `lease_required`) and applies TOON encoding via `self._apply_toon_encoding`.
- Replace all direct `await call_next()` usages with `return await _call_tool()` so post-call consumption and encoding are centralized.
- Preserve existing `ToolError` behavior when consumption fails after a successful call by raising an error if `consume` returns `None`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966c84613e083269d67ecf73d7fb0a6)