### PR TITLE
Add LLM gateway and route RetrievalExplainer calls through it

### DIFF
--- a/src/meta_mcp/llm_gateway.py
+++ b/src/meta_mcp/llm_gateway.py
@@ -1,0 +1,30 @@
+"""Canonical LLM gateway for model invocations."""
+
+import logging
+from typing import Any, Dict, List
+
+logger = logging.getLogger(__name__)
+
+
+def call_model(
+    model: str,
+    messages: List[Dict[str, str]],
+    temperature: float,
+    client: Any,
+) -> str:
+    """Call the LLM client with standard logging and error handling."""
+    try:
+        kwargs = {
+            "model": model,
+            "messages": messages,
+            "temperature": temperature,
+        }
+
+        if "gpt" in model.lower() or "o1" in model.lower():
+            kwargs["response_format"] = {"type": "json_object"}
+
+        response = client.completion(**kwargs)
+        return response.choices[0].message.content
+    except Exception as exc:
+        logger.error("LLM call failed: %s", exc)
+        raise RuntimeError(f"LLM call failed: {exc}") from exc


### PR DESCRIPTION
### Motivation
- Centralize LLM invocation, logging, response formatting and error handling to avoid duplicated logic across callers.
- Ensure consistent extraction of model content (`choices[0].message.content`) while enabling model-specific response formatting options.

### Description
- Add `src/meta_mcp/llm_gateway.py` implementing `call_model(model, messages, temperature, client)` which prepares `kwargs`, sets `response_format` for models containing `gpt` or `o1`, calls `client.completion(**kwargs)`, returns `response.choices[0].message.content`, and wraps exceptions with logging and `RuntimeError`.
- Update `RetrievalExplainer._call_llm` in `src/meta_mcp/rag/explainer/explainer.py` to build the `messages` list and invoke the gateway via `call_model(...)` instead of calling `self.llm_client.completion(...)` directly.
- Move the try/except error handling out of `_call_llm` into the gateway so callers receive consistent errors and logging, while preserving the original response extraction behavior.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966cb49ac588326a90ed6a725cb50a4)