### PR TITLE
Add HookManager and wrap tool execution with pre/post hooks

### DIFF
--- a/src/meta_mcp/hooks.py
+++ b/src/meta_mcp/hooks.py
@@ -1,0 +1,25 @@
+"""Hook manager for tool execution lifecycle."""
+
+from typing import Any, Dict
+
+from fastmcp import Context
+
+
+class HookManager:
+    """Provide pre/post hooks around tool execution.
+
+    Default implementations are no-ops and must not mutate arguments or results.
+    """
+
+    def before_tool_call(
+        self, ctx: Context, tool_name: str, args: Dict[str, Any]
+    ) -> None:
+        """Called before a tool is executed."""
+
+    def after_tool_call(
+        self, ctx: Context, tool_name: str, args: Dict[str, Any], result: Any
+    ) -> None:
+        """Called after a tool is executed."""
+
+
+hook_manager = HookManager()


### PR DESCRIPTION
### Motivation
- Provide an extension point to run pre/post hooks around tool execution without changing existing behavior, starting with no-op defaults.

### Description
- Add `src/meta_mcp/hooks.py` which defines a `HookManager` class with `before_tool_call(ctx, tool_name, args)` and `after_tool_call(ctx, tool_name, args, result)` and exposes a singleton `hook_manager` whose methods are no-ops by default.
- Wrap tool invocation in `GovernanceMiddleware.on_call_tool` by introducing an `invoke_tool()` helper that calls `hook_manager.before_tool_call`, awaits `call_next()`, then calls `hook_manager.after_tool_call`, and replace direct `call_next()` usages with `invoke_tool()` on execution paths so results and arguments are not mutated.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966cb39467883269c3b4d66a8d2205a)