### PR TITLE
Add no-op HookManager and integrate pre/post tool hooks into middleware

### DIFF
--- a/src/meta_mcp/hooks.py
+++ b/src/meta_mcp/hooks.py
@@ -1,0 +1,23 @@
+"""Hook system for tool execution lifecycle."""
+
+from typing import Any, Dict
+
+from fastmcp import Context
+
+
+class HookManager:
+    """No-op hook manager for tool execution lifecycle."""
+
+    def before_tool_call(
+        self, ctx: Context, tool_name: str, args: Dict[str, Any]
+    ) -> None:
+        """Run before a tool is invoked."""
+
+    def after_tool_call(
+        self,
+        ctx: Context,
+        tool_name: str,
+        args: Dict[str, Any],
+        result: Any,
+    ) -> None:
+        """Run after a tool is invoked."""


### PR DESCRIPTION
### Motivation

- Provide extension points to run pre/post logic around tool execution without changing runtime behavior.
- Start with a no-op implementation so hooks can be safely added later without side effects.
- Integrate hooks into the governance execution paths so future hook implementations will run for all tool invocations.

### Description

- Add a new module `src/meta_mcp/hooks.py` defining a `HookManager` with `before_tool_call(ctx, tool_name, args)` and `after_tool_call(ctx, tool_name, args, result)` methods that are no-ops by default.
- Instantiate a `hook_manager = HookManager()` in `src/meta_mcp/middleware.py` and add an async helper `GovernanceMiddleware._invoke_tool(...)` that calls `hook_manager.before_tool_call`, awaits `call_next()`, then calls `hook_manager.after_tool_call` and returns the result.
- Replace direct `await call_next()` invocations in the governance paths (BYPASS, non-sensitive, elevation-used, and post-approval execution branches) with calls to `self._invoke_tool(...)`; the default hooks do not mutate arguments or results.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966cb36d6bc83268a63d025ca9b70ee)