### PR TITLE
Add HookManager and invoke_tool gateway for tool call hooks

### DIFF
--- a/src/meta_mcp/tooling/__init__.py
+++ b/src/meta_mcp/tooling/__init__.py
@@ -1,0 +1,5 @@
+"""Tooling helpers and lifecycle hooks for MetaMCP."""
+
+from .hooks import HookManager, hook_manager
+
+__all__ = ["HookManager", "hook_manager"]

--- a/src/meta_mcp/tooling/hooks.py
+++ b/src/meta_mcp/tooling/hooks.py
@@ -1,0 +1,51 @@
+"""Tool call hooks for MetaMCP tooling gateway."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from fastmcp import Context
+
+
+class HookManager:
+    """
+    Manage pre/post tool call hooks.
+
+    Hooks are no-ops by default and can be customized by overriding methods.
+    """
+
+    def before_tool_call(
+        self, ctx: Context, tool_name: str, args: dict[str, Any]
+    ) -> None:
+        """
+        Hook invoked before tool execution.
+
+        Args:
+            ctx: FastMCP context
+            tool_name: Name of the tool being invoked
+            args: Tool arguments
+        """
+        return None
+
+    def after_tool_call(
+        self,
+        ctx: Context,
+        tool_name: str,
+        args: dict[str, Any],
+        result: Any,
+        error: Optional[BaseException],
+    ) -> None:
+        """
+        Hook invoked after tool execution.
+
+        Args:
+            ctx: FastMCP context
+            tool_name: Name of the tool being invoked
+            args: Tool arguments
+            result: Tool result (if successful)
+            error: Exception instance if tool raised
+        """
+        return None
+
+
+hook_manager = HookManager()


### PR DESCRIPTION
### Motivation

- Provide pre/post call lifecycle hooks for tool invocations so additional behavior (logging/metrics/side-effects) can be added without changing middleware logic.
- Preserve existing behavior by making hooks no-ops by default so tool results remain identical unless hooks are customized.

### Description

- Add `HookManager` class with `before_tool_call(ctx, tool_name, args)` and `after_tool_call(ctx, tool_name, args, result, error)` and export a module-level singleton `hook_manager` in `src/meta_mcp/tooling/hooks.py` and `src/meta_mcp/tooling/__init__.py`.
- Add `invoke_tool(ctx, tool_name, args, call_next)` to `src/meta_mcp/middleware.py` that runs `hook_manager.before_tool_call` before execution and `hook_manager.after_tool_call` after execution (including error paths).
- Wire `invoke_tool` into the governance middleware by replacing direct `await call_next()` invocations with `await invoke_tool(context, tool_name, arguments, call_next)` in all execution paths so hooks are invoked for BYPASS, non-sensitive, elevation-used, and post-approval tool runs.

### Testing

- No automated tests were run as part of this change.
- The hooks are implemented as no-ops by default so existing behavior and tool results should be preserved when `hook_manager` is not customized.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966ca8de0ec8326b101f6efccbd75d7)