### PR TITLE
Introduce `model_call` LLM gateway and route RetrievalExplainer through it

### DIFF
--- a/src/meta_mcp/llm/__init__.py
+++ b/src/meta_mcp/llm/__init__.py
@@ -1,0 +1,5 @@
+"""LLM utilities for Meta MCP."""
+
+from .gateway import model_call
+
+__all__ = ["model_call"]

--- a/src/meta_mcp/llm/gateway.py
+++ b/src/meta_mcp/llm/gateway.py
@@ -1,0 +1,27 @@
+"""LLM gateway utilities."""
+
+from typing import Any, Dict, List, Optional
+
+try:
+    import litellm
+except ImportError:
+    litellm = None
+
+
+def model_call(model: str, messages: List[Dict[str, str]], **kwargs: Any) -> Any:
+    """
+    Forward an LLM completion call through the configured client.
+
+    Args:
+        model: Model identifier.
+        messages: Chat messages for the completion.
+        **kwargs: Additional parameters, including optional llm_client.
+
+    Returns:
+        LLM response object.
+    """
+    llm_client = kwargs.pop("llm_client", None) or litellm
+    if llm_client is None:
+        raise RuntimeError("LLM client is not available")
+
+    return llm_client.completion(model=model, messages=messages, **kwargs)

--- a/src/meta_mcp/rag/explainer/explainer.py
+++ b/src/meta_mcp/rag/explainer/explainer.py
@@ -19,6 +19,7 @@ try:
 except ImportError:
     litellm = None
 
+from ...llm.gateway import model_call
 from ..retrieval import RetrievalCandidate
 
 logger = logging.getLogger(__name__)
@@ -410,8 +411,8 @@ class RetrievalExplainer:
             if "gpt" in self.model.lower() or "o1" in self.model.lower():
                 kwargs["response_format"] = {"type": "json_object"}
 
-            # Call LLM via litellm
-            response = self.llm_client.completion(**kwargs)
+            # Call LLM via gateway
+            response = model_call(**kwargs, llm_client=self.llm_client)
 
             # Extract content
             content = response.choices[0].message.content


### PR DESCRIPTION
### Motivation

- Centralize LLM invocation behind a single gateway to make future tracing and instrumentation easier. 
- Provide a single entrypoint that can forward to the configured LLM client instead of calling the client directly. 
- Replace direct `self.llm_client.completion` usage in the retrieval explainer so all model calls go through the gateway.

### Description

- Add a new gateway module `src/meta_mcp/llm/gateway.py` implementing `model_call(model, messages, **kwargs)` that forwards to the provided `llm_client` or to `litellm` and raises if no client is available.
- Expose the gateway helper via `src/meta_mcp/llm/__init__.py` with `__all__ = ["model_call"]`.
- Update `src/meta_mcp/rag/explainer/explainer.py` to import `model_call` and replace the direct `self.llm_client.completion(**kwargs)` call with `model_call(**kwargs, llm_client=self.llm_client)` while keeping the response content extraction unchanged (`response.choices[0].message.content`).

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966cacdc8bc8326823ae10462d65904)