### PR TITLE
Add PermissionRequest and centralize approval request construction

### DIFF
--- a/src/meta_mcp/governance/__init__.py
+++ b/src/meta_mcp/governance/__init__.py
@@ -18,6 +18,7 @@ from .artifacts import (
     ArtifactGenerationError,
     get_artifact_generator,
 )
+from .permission import PermissionRequest
 from .policy import PolicyDecision, evaluate_policy
 from .tokens import decode_token, generate_token, verify_token
 
@@ -38,4 +39,5 @@ __all__ = [
     "ApprovalArtifactGenerator",
     "ArtifactGenerationError",
     "get_artifact_generator",
+    "PermissionRequest",
 ]

--- a/src/meta_mcp/governance/permission.py
+++ b/src/meta_mcp/governance/permission.py
@@ -1,0 +1,21 @@
+"""Permission request models for governance."""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class PermissionRequest:
+    """Structured permission request for a tool operation.
+
+    Attributes mirror ApprovalRequest with an optional run_context for richer context.
+    """
+
+    request_id: str
+    tool_name: str
+    message: str
+    required_scopes: List[str]
+    artifacts_path: Optional[str] = None
+    timeout_seconds: int = 300
+    context_metadata: Dict[str, Any] = field(default_factory=dict)
+    run_context: Optional[Any] = None


### PR DESCRIPTION
### Motivation

- Consolidate all permission request data into a single structured model to avoid ad-hoc dictionaries and make future extensions (e.g., run context) easier to support.
- Preserve the existing `ApprovalRequest` API while providing a single place to build and convert permission details before eliciting approval.

### Description

- Add `PermissionRequest` dataclass with fields mirroring `ApprovalRequest` plus an optional `run_context` at `src/meta_mcp/governance/permission.py`.
- Add `GovernanceMiddleware._build_permission_request` to produce a `PermissionRequest` from `ctx`, `tool_name`, and `arguments`, reusing existing logic for `request_id`, `required_scopes`, message formatting, and artifact generation.
- Add `GovernanceMiddleware._to_approval_request` to convert a `PermissionRequest` to the existing `ApprovalRequest` in one place and update `_elicit_approval` to use these helpers instead of inline construction.
- Export `PermissionRequest` from the governance package to make the new type available to other modules.
- Ensure request_id, required_scopes, artifacts_path, timeout_seconds, and `context_metadata` are produced using the same logic as before so the elicitation payload is unchanged; `run_context` is added without altering `ApprovalRequest` shape.

### Testing

- No automated tests were executed as part of this change (no CI/unit tests run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966cb300d3083268359ec1543a756c8)