### PR TITLE
Add RunContext metadata for tool invocations

### DIFF
--- a/src/meta_mcp/context.py
+++ b/src/meta_mcp/context.py
@@ -1,0 +1,26 @@
+"""Context utilities for tool execution and governance."""
+
+from dataclasses import dataclass
+from typing import Optional
+
+from .leases.models import ToolLease
+
+
+@dataclass
+class RunContext:
+    """
+    Structured metadata for a tool invocation.
+
+    Attributes:
+        run_id: External run identifier, if provided by the caller.
+        lease: Validated and consumed lease information, if available.
+        agent_id: Agent identifier from the request context, if provided.
+        client_id: Stable client/session identifier.
+        tool_name: Name of the tool being invoked.
+    """
+
+    run_id: Optional[str]
+    lease: Optional[ToolLease]
+    agent_id: Optional[str]
+    client_id: str
+    tool_name: str


### PR DESCRIPTION
### Motivation

- Provide a structured context object to carry run/lease/agent metadata through tool invocation and approval flows so hooks/providers can access consistent invocation metadata.

### Description

- Add a new `RunContext` dataclass in `src/meta_mcp/context.py` with fields `run_id`, `lease`, `agent_id`, `client_id`, and `tool_name`.
- Add helper `_get_request_context_value` to extract `run_id`/`agent_id` from the FastMCP `request_context` (metadata or attributes) and use it in `_elicit_approval` and `on_call_tool`.
- Include `run_id` and `agent_id` in approval artifact generation and in `ApprovalRequest.context_metadata` so approval providers receive the new fields (additive to existing `session_id`, `context_key`, `arguments`).
- Build a `RunContext` instance inside `on_call_tool` after lease validation/consumption and pass it into downstream execution by calling `call_next(run_context=run_context)` on all execution paths.
- Preserve existing metadata fields and behavior; new fields are additive only.

### Testing

- No automated tests were executed as part of this change (no test run requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966cb1261b083268675f8bcfbdb19af)