### PR TITLE
Centralize permission scope builder and add LLM invoke wrapper

### DIFF
--- a/src/meta_mcp/governance/permissions.py
+++ b/src/meta_mcp/governance/permissions.py
@@ -1,0 +1,63 @@
+"""Permission scope builder for tool governance."""
+
+from typing import Any, Dict, List
+
+from loguru import logger
+
+from ..registry import tool_registry
+
+
+def build_required_scopes(tool_name: str, arguments: Dict[str, Any]) -> List[str]:
+    """
+    Get required permission scopes for a tool operation.
+
+    Fetches base scopes from tool registry metadata, then adds
+    resource-specific scopes based on tool arguments (e.g., specific file paths).
+
+    Args:
+        tool_name: Name of the tool
+        arguments: Tool arguments
+
+    Returns:
+        List of required permission scopes
+    """
+    # Start with base scopes from registry
+    tool_record = tool_registry.get_tool(tool_name)
+    if tool_record and tool_record.required_scopes:
+        base_scopes = tool_record.required_scopes.copy()
+    else:
+        # Fallback: generate basic scope if not in registry
+        logger.warning(
+            f"Tool {tool_name} not found in registry or has no required_scopes, "
+            f"using fallback scope"
+        )
+        base_scopes = [f"tool:{tool_name}"]
+
+    # Add resource-specific scopes based on arguments
+    # These are dynamic and depend on actual operation context
+    if tool_name in {"write_file", "delete_file", "read_file"}:
+        path = arguments.get("path", "")
+        if path:
+            base_scopes.append(f"resource:path:{path}")
+
+    elif tool_name == "move_file":
+        source = arguments.get("source", "")
+        dest = arguments.get("destination", "")
+        if source:
+            base_scopes.append(f"resource:path:{source}")
+        if dest:
+            base_scopes.append(f"resource:path:{dest}")
+
+    elif tool_name == "execute_command":
+        command = arguments.get("command", "")
+        if command:
+            # Add specific command being executed (first 50 chars)
+            cmd_preview = command[:50] if len(command) > 50 else command
+            base_scopes.append(f"resource:command:{cmd_preview}")
+
+    elif tool_name in {"create_directory", "list_directory"}:
+        path = arguments.get("path", "")
+        if path:
+            base_scopes.append(f"resource:path:{path}")
+
+    return base_scopes

--- a/src/meta_mcp/rag/explainer/invocation.py
+++ b/src/meta_mcp/rag/explainer/invocation.py
@@ -1,0 +1,54 @@
+"""Wrapper utilities for LLM tool invocation."""
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _supports_json_format(model: str) -> bool:
+    model_lower = model.lower()
+    return "gpt" in model_lower or "o1" in model_lower
+
+
+def invoke_tool(
+    llm_client: Any,
+    model: str,
+    system_prompt: str,
+    user_prompt: str,
+    temperature: float,
+) -> str:
+    """
+    Invoke the LLM tool with standardized prompt formatting.
+
+    Args:
+        llm_client: LLM client (litellm or compatible).
+        model: Model identifier for LLM calls.
+        system_prompt: System prompt text.
+        user_prompt: User prompt text.
+        temperature: Sampling temperature.
+
+    Returns:
+        LLM response content.
+    """
+    try:
+        messages = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt},
+        ]
+
+        kwargs = {
+            "model": model,
+            "messages": messages,
+            "temperature": temperature,
+        }
+
+        if _supports_json_format(model):
+            kwargs["response_format"] = {"type": "json_object"}
+
+        response = llm_client.completion(**kwargs)
+        return response.choices[0].message.content
+
+    except Exception as e:
+        logger.error(f"LLM call failed: {e}")
+        raise RuntimeError(f"LLM call failed: {e}") from e


### PR DESCRIPTION
### Motivation

- Remove duplicated inline permission-building logic from middleware and centralize it so approval flows use a single source of truth. 
- Standardize LLM invocation for the retrieval explainer behind a wrapper to simplify response-format handling and make future changes to invocation behavior easier.

### Description

- Add `src/meta_mcp/governance/permissions.py` implementing `build_required_scopes(tool_name, arguments)` and move scope construction there. 
- Update `src/meta_mcp/middleware.py` to consume `build_required_scopes` and remove the old inline `_get_required_scopes` implementation, plus minor typing/import cleanups. 
- Add `src/meta_mcp/rag/explainer/invocation.py` with `invoke_tool(...)` to standardize LLM calls and update `src/meta_mcp/rag/explainer/explainer.py` to call the explainer LLM via `invoke_tool`. 
- Changes keep existing audit and approval flows intact while routing scope-building and LLM calls through the new wrappers.

### Testing

- No automated tests were run as part of this change (no test suite executed).
- Manual / runtime verification was not performed in this PR; recommended follow-ups are: run unit tests, exercise approval/deny flows, and verify audit log events (`tool_invoked`, `approval_requested`, `approval_granted/denied`, `scoped_elevation_granted/used`) in a controlled environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966cade2814832683e08f3e4d2034c5)