### PR TITLE
Update README documentation links and GUI approval note

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ pip install -e ".[gui-approval]"
 - GNOME Shell (tested on version 40+)
 - Wayland session
 - DBus session bus access
-- GNOME Shell extension (see `GUIPlan/` directory for installation)
+- GNOME Shell extension (installation notes forthcoming)
 
 **Fallback Options:**
 If GUI approval is not available, the system automatically falls back to:
@@ -121,18 +121,9 @@ Sensitive operations trigger approval flows with:
 ## Documentation
 
 ### Core Documentation
-- `.MCP/DEVELOPER_REFERENCE.md` - Complete developer guide with patterns and gotchas
-- `.MCP/ARCHITECTURE_MAP.md` - Directory structure and component layout
-- `.MCP/GAP_ANALYSIS_REPORT.md` - Implementation status and gaps
-- `.MCP/IMPLEMENTATION_PLAN.md` - Current TODO lists and planning
-
-### GUI Approval System
-- `GUIPlan/APPROVAL_SYSTEM.md` - Complete GUI approval system guide
-  - Approval provider architecture and selection
-  - **Server-side scope enforcement** (ALL required scopes must be approved)
-  - Lease semantics (single-use vs persistent elevations)
-  - Security model and fail-safe defaults
-  - Deployment guide and troubleshooting
+- `AGENT_ARCHITECTURE_DESIGN.md` - Architecture design for the agent runtime and governance integration
+- `tests/SECURITY_TESTS_README.md` - Security test coverage and execution notes
+- `config/client_configs.md` - Client configuration examples
 
 ## Testing
 


### PR DESCRIPTION
### Motivation
- The README referenced a non-existent `GUIPlan/APPROVAL_SYSTEM.md` and several `.MCP` documents, so the doc list and GUI approval section needed to be aligned with the repository's current files.

### Description
- Updated the GUI approval note to remove the stale `GUIPlan` reference and replaced the `.MCP`/GUIPlan documentation list with links to `AGENT_ARCHITECTURE_DESIGN.md`, `tests/SECURITY_TESTS_README.md`, and `config/client_configs.md` in `README.md`.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966c8ccf4608326862f3b21db368f6c)