### PR TITLE
Centralize workspace root and command timeout in Config

### DIFF
--- a/servers/core_tools.py
+++ b/servers/core_tools.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import json
-import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -12,11 +11,7 @@ from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
 from loguru import logger
 
-
-# Constants
-WORKSPACE_ROOT = os.getenv("WORKSPACE_ROOT", "./workspace")
-COMMAND_TIMEOUT = 30
-
+from src.meta_mcp.config import Config
 
 # Create FastMCP server instance
 core_server = FastMCP("CoreTools")
@@ -35,7 +30,7 @@ def _validate_path(path: str) -> Path:
     Raises:
         ToolError: If path is outside WORKSPACE_ROOT
     """
-    workspace = Path(WORKSPACE_ROOT).resolve()
+    workspace = Path(Config.WORKSPACE_ROOT).resolve()
     target = (workspace / path).resolve()
 
     # Check if target is within workspace using is_relative_to (Python 3.9+)
@@ -252,7 +247,7 @@ def execute_command(command: str, cwd: Optional[str] = None) -> str:
     """
     # Validate and resolve working directory
     if cwd is None:
-        work_dir = Path(WORKSPACE_ROOT).resolve()
+        work_dir = Path(Config.WORKSPACE_ROOT).resolve()
     else:
         work_dir = _validate_path(cwd)
         if not work_dir.is_dir():
@@ -265,7 +260,7 @@ def execute_command(command: str, cwd: Optional[str] = None) -> str:
             cwd=str(work_dir),
             capture_output=True,
             text=True,
-            timeout=COMMAND_TIMEOUT,
+            timeout=Config.COMMAND_TIMEOUT,
             encoding="utf-8",
             errors="replace",
         )
@@ -281,7 +276,7 @@ def execute_command(command: str, cwd: Optional[str] = None) -> str:
 
     except subprocess.TimeoutExpired:
         raise ToolError(
-            f"Command timed out after {COMMAND_TIMEOUT} seconds: {command}"
+            f"Command timed out after {Config.COMMAND_TIMEOUT} seconds: {command}"
         )
     except Exception as e:
         raise ToolError(f"Failed to execute command: {e}")
@@ -307,7 +302,7 @@ async def git_commit(message: str, cwd: Optional[str] = None) -> str:
     """
     # Validate and resolve working directory
     if cwd is None:
-        work_dir = Path(WORKSPACE_ROOT).resolve()
+        work_dir = Path(Config.WORKSPACE_ROOT).resolve()
     else:
         work_dir = _validate_path(cwd)
         if not work_dir.is_dir():
@@ -320,7 +315,7 @@ async def git_commit(message: str, cwd: Optional[str] = None) -> str:
             cwd=str(work_dir),
             capture_output=True,
             text=True,
-            timeout=COMMAND_TIMEOUT,
+            timeout=Config.COMMAND_TIMEOUT,
             encoding="utf-8",
             errors="replace",
         )
@@ -338,7 +333,7 @@ async def git_commit(message: str, cwd: Optional[str] = None) -> str:
         return json.dumps(output, indent=2)
 
     except subprocess.TimeoutExpired:
-        raise ToolError(f"Git commit timed out after {COMMAND_TIMEOUT}s")
+        raise ToolError(f"Git commit timed out after {Config.COMMAND_TIMEOUT}s")
     except Exception as e:
         raise ToolError(f"Git commit error: {e}")
 
@@ -366,7 +361,7 @@ async def git_push(
     """
     # Validate and resolve working directory
     if cwd is None:
-        work_dir = Path(WORKSPACE_ROOT).resolve()
+        work_dir = Path(Config.WORKSPACE_ROOT).resolve()
     else:
         work_dir = _validate_path(cwd)
         if not work_dir.is_dir():
@@ -384,7 +379,7 @@ async def git_push(
             cwd=str(work_dir),
             capture_output=True,
             text=True,
-            timeout=COMMAND_TIMEOUT,
+            timeout=Config.COMMAND_TIMEOUT,
             encoding="utf-8",
             errors="replace",
         )
@@ -402,7 +397,7 @@ async def git_push(
         return json.dumps(output, indent=2)
 
     except subprocess.TimeoutExpired:
-        raise ToolError(f"Git push timed out after {COMMAND_TIMEOUT}s")
+        raise ToolError(f"Git push timed out after {Config.COMMAND_TIMEOUT}s")
     except Exception as e:
         raise ToolError(f"Git push error: {e}")
 
@@ -432,7 +427,7 @@ async def git_reset(
     """
     # Validate and resolve working directory
     if cwd is None:
-        work_dir = Path(WORKSPACE_ROOT).resolve()
+        work_dir = Path(Config.WORKSPACE_ROOT).resolve()
     else:
         work_dir = _validate_path(cwd)
         if not work_dir.is_dir():
@@ -451,7 +446,7 @@ async def git_reset(
             cwd=str(work_dir),
             capture_output=True,
             text=True,
-            timeout=COMMAND_TIMEOUT,
+            timeout=Config.COMMAND_TIMEOUT,
             encoding="utf-8",
             errors="replace",
         )
@@ -470,7 +465,7 @@ async def git_reset(
         return json.dumps(output, indent=2)
 
     except subprocess.TimeoutExpired:
-        raise ToolError(f"Git reset timed out after {COMMAND_TIMEOUT}s")
+        raise ToolError(f"Git reset timed out after {Config.COMMAND_TIMEOUT}s")
     except Exception as e:
         raise ToolError(f"Git reset error: {e}")
 

--- a/src/meta_mcp/config.py
+++ b/src/meta_mcp/config.py
@@ -29,6 +29,7 @@ class Config:
     PORT: int = _parse_port.__func__(os.getenv("PORT", "8001"))
     WORKSPACE_ROOT: str = os.getenv("WORKSPACE_ROOT", "./workspace")
     AUDIT_LOG_PATH: str = os.getenv("AUDIT_LOG_PATH", "./audit.jsonl")
+    COMMAND_TIMEOUT: int = int(os.getenv("COMMAND_TIMEOUT", "30"))
 
     # ========================================================================
     # Redis Configuration

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,6 +10,7 @@ def test_config_defaults():
     assert Config.DEFAULT_ELEVATION_TTL == 300
     assert Config.ELICITATION_TIMEOUT == 300
     assert Config.WORKSPACE_ROOT == "./workspace"
+    assert Config.COMMAND_TIMEOUT == 30
 
 
 def test_config_lease_ttl_positive():

--- a/tests/test_todo_list_2.py
+++ b/tests/test_todo_list_2.py
@@ -34,9 +34,10 @@ def core_tools_module(tmp_path, monkeypatch):
     Load core_tools with an isolated WORKSPACE_ROOT for filesystem tests.
     """
     monkeypatch.setenv("WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setattr(Config, "WORKSPACE_ROOT", str(tmp_path))
     import servers.core_tools as core_tools
     importlib.reload(core_tools)
-    Path(core_tools.WORKSPACE_ROOT).mkdir(parents=True, exist_ok=True)
+    Path(Config.WORKSPACE_ROOT).mkdir(parents=True, exist_ok=True)
     return core_tools
 
 
@@ -65,7 +66,7 @@ def test_remove_directory_succeeds_on_valid_directory(core_tools_module):
     remove_directory = core_tools_module.remove_directory
 
     # Create temporary test directory with contents
-    workspace = Path(core_tools_module.WORKSPACE_ROOT)
+    workspace = Path(Config.WORKSPACE_ROOT)
     test_dir = workspace / "test_remove_dir"
     test_dir.mkdir(parents=True, exist_ok=True)
 
@@ -114,7 +115,7 @@ def test_remove_directory_fails_on_file_path(core_tools_module):
     remove_directory = core_tools_module.remove_directory
 
     # Create a file (not a directory)
-    workspace = Path(core_tools_module.WORKSPACE_ROOT)
+    workspace = Path(Config.WORKSPACE_ROOT)
     test_file = workspace / "test_file.txt"
     test_file.write_text("not a directory")
 
@@ -140,7 +141,7 @@ def test_remove_directory_recursive_deletion(core_tools_module):
     remove_directory = core_tools_module.remove_directory
 
     # Create complex directory structure
-    workspace = Path(core_tools_module.WORKSPACE_ROOT)
+    workspace = Path(Config.WORKSPACE_ROOT)
     test_dir = workspace / "test_recursive"
     test_dir.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
### Motivation

- Centralize environment-driven settings so workspace root and command timeout are discoverable and documented via the `Config` class.
- Make `COMMAND_TIMEOUT` configurable through environment variables instead of hard-coding numeric literals.
- Update tests to rely on the centralized config to avoid divergence between code and test fixtures.

### Description

- Added `COMMAND_TIMEOUT` to `src/meta_mcp/config.py` with a default of `30` and an override via the `COMMAND_TIMEOUT` environment variable.
- Updated `servers/core_tools.py` to import `Config` and replace `WORKSPACE_ROOT` and `COMMAND_TIMEOUT` uses with `Config.WORKSPACE_ROOT` and `Config.COMMAND_TIMEOUT` respectively.
- Modified `tests/test_todo_list_2.py` to set `Config.WORKSPACE_ROOT` in the fixture and to use `Config.WORKSPACE_ROOT` when creating test files and directories.
- Added an assertion for the new default in `tests/test_config.py` (`Config.COMMAND_TIMEOUT == 30`) and retained original path validation and timeout messaging behavior.

### Testing

- No automated test suite was executed as part of this change.
- Unit tests were updated: `tests/test_todo_list_2.py` (filesystem fixture changes) and `tests/test_config.py` (added `COMMAND_TIMEOUT` assertion), but they were not run here.
- Static/behavioral inspection confirms path validation still resolves against the same workspace root and command timeout defaults and messages remain semantically identical after switching to `Config` access.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966c8ef94088326910254be8a821dd1)