### PR TITLE
Add explicit request_tool_access lease flow and opt-out schema-lease compatibility

### DIFF
--- a/src/config/tools.yaml
+++ b/src/config/tools.yaml
@@ -193,8 +193,7 @@ tools:
   description_1line: Get JSON schema for a specific tool.
   description_full: 'Get JSON schema for a specific tool.
 
-    This is the gateway to tool access - schemas are not visible until explicitly requested. Progressive
-    discovery mechanism.'
+    Schemas are not visible until explicitly requested. Progressive discovery mechanism.'
   tags:
   - core
   - get
@@ -205,6 +204,22 @@ tools:
   required_scopes:
   - tool:get_tool_schema
   - meta:schema
+- tool_id: request_tool_access
+  server_id: core_tools
+  description_1line: Request authorization to call a tool.
+  description_full: 'Request authorization to call a tool.
+
+    Grants a time-limited lease for tool invocation after governance checks.'
+  tags:
+  - core
+  - meta
+  - access
+  - lease
+  risk_level: safe
+  requires_permission: false
+  required_scopes:
+  - tool:request_tool_access
+  - meta:access
 - tool_id: git_commit
   server_id: core_tools
   description_1line: Create a git commit with staged changes.

--- a/src/meta_mcp/config.py
+++ b/src/meta_mcp/config.py
@@ -81,6 +81,9 @@ class Config:
     ENABLE_LEASE_MANAGEMENT: bool = True     # Phase 3
     ENABLE_PROGRESSIVE_SCHEMAS: bool = False # Phase 5
     ENABLE_MACROS: bool = True               # Phase 7
+    ENABLE_SCHEMA_LEASE_COMPAT: bool = os.getenv(
+        "ENABLE_SCHEMA_LEASE_COMPAT", "false"
+    ).lower() in {"1", "true", "yes"}
 
     @classmethod
     def validate(cls) -> bool:

--- a/src/meta_mcp/discovery.py
+++ b/src/meta_mcp/discovery.py
@@ -131,6 +131,7 @@ class ToolRegistry:
         ONLY these tools are exposed at startup:
         - search_tools: Entry point for discovery
         - get_tool_schema: Triggers tool exposure (progressive discovery)
+        - request_tool_access: Explicit lease grant path
 
         All other tools (including read_file, list_directory) are:
         1. Registered in this registry (searchable via search_tools)
@@ -140,9 +141,9 @@ class ToolRegistry:
         This implements true progressive discovery.
 
         Returns:
-            List of 2 bootstrap tool names
+            List of bootstrap tool names
         """
-        return ["search_tools", "get_tool_schema"]
+        return ["search_tools", "get_tool_schema", "request_tool_access"]
 
     def get_all_summaries(self) -> List[ToolSummary]:
         """

--- a/src/meta_mcp/governance/policy.py
+++ b/src/meta_mcp/governance/policy.py
@@ -54,7 +54,7 @@ def evaluate_policy(
     Design Plan Section 5.5
     """
     # Bootstrap tools are always allowed
-    if tool_id in {"search_tools", "get_tool_schema"}:
+    if tool_id in {"search_tools", "get_tool_schema", "request_tool_access"}:
         return PolicyDecision(
             action="allow",
             requires_approval=False,

--- a/src/meta_mcp/middleware.py
+++ b/src/meta_mcp/middleware.py
@@ -648,7 +648,7 @@ class GovernanceMiddleware(Middleware):
         # PHASE 3+4 INTEGRATION: Validate lease and token before governance checks
         # Note: Bootstrap tools bypass lease checks
         # CRITICAL: Skip lease checks if ENABLE_LEASE_MANAGEMENT is False
-        bootstrap_tools = {"search_tools", "get_tool_schema"}
+        bootstrap_tools = {"search_tools", "get_tool_schema", "request_tool_access"}
 
         if Config.ENABLE_LEASE_MANAGEMENT and tool_name not in bootstrap_tools:
             # Extract client_id from FastMCP session context
@@ -663,7 +663,7 @@ class GovernanceMiddleware(Middleware):
                 )
                 raise ToolError(
                     f"No valid lease for tool '{tool_name}'. "
-                    f"Please request tool schema first via get_tool_schema('{tool_name}')."
+                    f"Please request tool access via request_tool_access('{tool_name}')."
                 )
 
             # PHASE 4: Verify capability token if present
@@ -702,7 +702,7 @@ class GovernanceMiddleware(Middleware):
                 )
                 raise ToolError(
                     f"Lease exhausted for tool '{tool_name}'. "
-                    f"Please request a new lease via get_tool_schema('{tool_name}')."
+                    f"Please request a new lease via request_tool_access('{tool_name}')."
                 )
 
             logger.info(

--- a/src/meta_mcp/registry/registry.py
+++ b/src/meta_mcp/registry/registry.py
@@ -24,7 +24,11 @@ class ToolRegistry:
         """Initialize empty tool registry."""
         self._tools: Dict[str, ToolRecord] = {}
         self._servers: Dict[str, ServerRecord] = {}
-        self._bootstrap_tools = {"search_tools", "get_tool_schema"}
+        self._bootstrap_tools = {
+            "search_tools",
+            "get_tool_schema",
+            "request_tool_access",
+        }
 
     @classmethod
     def from_yaml(cls, yaml_path: str) -> "ToolRegistry":
@@ -185,11 +189,12 @@ class ToolRegistry:
         Bootstrap tools are:
         - search_tools: Entry point for discovery
         - get_tool_schema: Triggers tool exposure
+        - request_tool_access: Explicit lease grant path
 
         These tools are auto-exposed at startup and always available.
 
         Returns:
-            Set of 2 bootstrap tool names
+            Set of bootstrap tool names
         """
         return self._bootstrap_tools
 

--- a/tests/integration/test_full_discovery_flow.py
+++ b/tests/integration/test_full_discovery_flow.py
@@ -28,16 +28,17 @@ async def test_bootstrap_discovery(redis_client):
 
     Flow:
     1. System starts with minimal bootstrap set
-    2. Only search_tools and get_tool_schema are visible
+    2. Only search_tools, get_tool_schema, and request_tool_access are visible
     3. All other tools are hidden until explicitly requested
     """
     # Get bootstrap tools
     bootstrap = tool_registry.get_bootstrap_tools()
 
     # Verify minimal set
-    assert len(bootstrap) == 2
+    assert len(bootstrap) == 3
     assert "search_tools" in bootstrap
     assert "get_tool_schema" in bootstrap
+    assert "request_tool_access" in bootstrap
 
     # Verify other tools are registered but not exposed
     assert tool_registry.is_registered("read_file")
@@ -122,6 +123,7 @@ async def test_progressive_schema_delivery(redis_client):
     bootstrap_tools = tool_registry.get_bootstrap_tools()
     assert "search_tools" in bootstrap_tools
     assert "get_tool_schema" in bootstrap_tools
+    assert "request_tool_access" in bootstrap_tools
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_lease_governance_flow.py
+++ b/tests/integration/test_lease_governance_flow.py
@@ -126,7 +126,7 @@ async def test_bootstrap_tools_always_allowed(redis_client):
     """
     Verify bootstrap tools are always allowed regardless of mode.
 
-    Security: search_tools and get_tool_schema must always work.
+    Security: bootstrap tools must always work.
     """
     for mode in [ExecutionMode.READ_ONLY, ExecutionMode.PERMISSION, ExecutionMode.BYPASS]:
         # search_tools always allowed
@@ -142,6 +142,14 @@ async def test_bootstrap_tools_always_allowed(redis_client):
             mode=mode,
             tool_risk="safe",
             tool_id="get_tool_schema"
+        )
+        assert decision.action == "allow"
+
+        # request_tool_access always allowed
+        decision = evaluate_policy(
+            mode=mode,
+            tool_risk="safe",
+            tool_id="request_tool_access"
         )
         assert decision.action == "allow"
 

--- a/tests/test_progressive_discovery.py
+++ b/tests/test_progressive_discovery.py
@@ -2,7 +2,7 @@
 Progressive Discovery Verification Tests
 
 Validates that the progressive discovery implementation meets all success criteria:
-- Initial exposure limited to 2 bootstrap tools
+- Initial exposure limited to 3 bootstrap tools
 - search_tools does not trigger exposure
 - get_tool_schema triggers exposure
 - Exposed tools persist
@@ -23,17 +23,19 @@ async def test_initial_exposure_minimal():
     At startup, only bootstrap tools should be exposed:
     - search_tools
     - get_tool_schema
+    - request_tool_access
     """
     # Get initial tool list
     tools = await mcp.get_tools()
     tool_names = sorted([t.name for t in tools.values()])
 
-    # Verify exactly 2 tools
-    assert len(tool_names) == 2, f"Expected 2 tools, got {len(tool_names)}: {tool_names}"
+    # Verify exactly 3 tools
+    assert len(tool_names) == 3, f"Expected 3 tools, got {len(tool_names)}: {tool_names}"
 
     # Verify correct tools
     assert "search_tools" in tool_names, "search_tools missing from bootstrap"
     assert "get_tool_schema" in tool_names, "get_tool_schema missing from bootstrap"
+    assert "request_tool_access" in tool_names, "request_tool_access missing from bootstrap"
 
     # Verify no other tools exposed
     assert "read_file" not in tool_names, "read_file should not be auto-exposed"
@@ -226,7 +228,7 @@ async def test_context_reduction_calculation():
         f"Expected at least 13 total tools, got {total_registered}"
 
     assert initially_exposed == 2, \
-        f"Expected 2 bootstrap tools, got {initially_exposed}"
+        f"Expected 3 bootstrap tools, got {initially_exposed}"
 
     assert reduction_percentage >= 75, \
         f"Context reduction is {reduction_percentage:.1f}%, expected >= 75%"
@@ -317,7 +319,7 @@ async def test_bootstrap_tools_always_available():
     """
     Verify bootstrap tools are always available without schema request.
 
-    search_tools and get_tool_schema should work without progressive discovery.
+    search_tools, get_tool_schema, and request_tool_access should work without progressive discovery.
     """
     # Both should be in tools/list initially
     tools = await mcp.get_tools()
@@ -327,6 +329,8 @@ async def test_bootstrap_tools_always_available():
         "search_tools must be available at startup"
     assert "get_tool_schema" in tool_names, \
         "get_tool_schema must be available at startup"
+    assert "request_tool_access" in tool_names, \
+        "request_tool_access must be available at startup"
 
     # Both should be immediately callable
     search_result = search_tools.fn(query="test")

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -14,9 +14,9 @@ def test_registry_loads_from_yaml():
 
 
 def test_bootstrap_tools_defined():
-    """Bootstrap tools must be exactly search_tools and get_tool_schema (Nuance 5.3)."""
+    """Bootstrap tools must include discovery and access helpers (Nuance 5.3)."""
     bootstrap = tool_registry.get_bootstrap_tools()
-    assert bootstrap == {"search_tools", "get_tool_schema"}
+    assert bootstrap == {"search_tools", "get_tool_schema", "request_tool_access"}
 
 
 def test_tool_record_validation():
@@ -82,7 +82,7 @@ def test_get_tool_not_found():
 def test_all_tools_have_required_fields():
     """All tools should have required metadata fields."""
     summaries = tool_registry.get_all_summaries()
-    assert len(summaries) == 15  # Total tools from YAML
+    assert len(summaries) == 16  # Total tools from YAML
 
     for tool in summaries:
         assert tool.tool_id
@@ -98,9 +98,11 @@ def test_bootstrap_tools_are_safe():
     """Bootstrap tools should have risk_level=safe (Nuance 5.3)."""
     search_tool = tool_registry.get("search_tools")
     schema_tool = tool_registry.get("get_tool_schema")
+    access_tool = tool_registry.get("request_tool_access")
 
     assert search_tool.risk_level == "safe"
     assert schema_tool.risk_level == "safe"
+    assert access_tool.risk_level == "safe"
 
 
 def test_sensitive_tools_require_permission():


### PR DESCRIPTION
### Motivation
- Separate schema exposure from authorization by introducing an explicit lease/authorization pathway so schema requests no longer implicitly mutate lease state. 
- Preserve backward compatibility for one release via a feature flag to avoid breaking callers that relied on schema-triggered leases. 

### Description
- Add a new `request_tool_access` MCP tool which performs governance evaluation and issues time-limited leases via the existing `lease_manager` (`src/meta_mcp/supervisor.py`).
- Move policy/lease issuance logic into a reusable `_grant_tool_lease` helper and add `_resolve_client_id` for consistent client-id extraction (`src/meta_mcp/supervisor.py`).
- Make `get_tool_schema()` read-only again (it only exposes schema); it will conditionally grant a lease only when the new `Config.ENABLE_SCHEMA_LEASE_COMPAT` flag is enabled to preserve legacy behavior (`src/meta_mcp/supervisor.py`).
- Register `request_tool_access` in the tools catalog and bootstrap set and mark it as a bootstrap-safe tool; update the policy and middleware bootstrap exemptions and user-facing messages to reference the new access tool (`src/config/tools.yaml`, `src/meta_mcp/registry/registry.py`, `src/meta_mcp/discovery.py`, `src/meta_mcp/governance/policy.py`, `src/meta_mcp/middleware.py`).
- Add a new feature flag `ENABLE_SCHEMA_LEASE_COMPAT` (default `false`) to `Config` to control compatibility mode (`src/meta_mcp/config.py`).
- Update and add unit/integration tests and expectations to cover the new bootstrap tool and the compatibility behavior, and adjust counts/readme references to account for the added tool (`tests/*`).

### Testing
- Updated automated tests include changes to `tests/test_todo_list_2.py` (compat-mode unit tests), `tests/test_registry.py`, `tests/test_progressive_discovery.py`, and integration tests to expect `request_tool_access` in the bootstrap set and verify compat-mode behaviors. 
- No test suite was executed as part of this change; the new and updated tests were committed but not run in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966c8f6edf0832686a61b8aff173c1d)