### PR TITLE
Add `invoke_tool` wrapper and centralize TOON encoding

### DIFF
--- a/src/meta_mcp/tooling/__init__.py
+++ b/src/meta_mcp/tooling/__init__.py
@@ -1,0 +1,2 @@
+"""Tooling helpers for Meta MCP."""
+

--- a/src/meta_mcp/tooling/invocation.py
+++ b/src/meta_mcp/tooling/invocation.py
@@ -1,0 +1,52 @@
+"""Tool invocation helpers."""
+
+from typing import Any, Awaitable, Callable, Dict
+
+from loguru import logger
+
+from ..config import Config
+from ..toon import encode_output
+
+
+def _apply_toon_encoding(result: Any) -> Any:
+    """
+    Apply TOON encoding to tool result if enabled.
+
+    Args:
+        result: Tool execution result
+
+    Returns:
+        Encoded result if TOON enabled, otherwise unchanged result
+    """
+    if not Config.ENABLE_TOON_OUTPUTS:
+        return result
+
+    try:
+        return encode_output(result, threshold=Config.TOON_ARRAY_THRESHOLD)
+    except Exception as e:
+        # Fail-safe: return original result if encoding fails
+        logger.warning(f"TOON encoding failed: {e}, returning original result")
+        return result
+
+
+async def invoke_tool(
+    ctx: Any,
+    tool_name: str,
+    args: Dict[str, Any],
+    call_next: Callable[[], Awaitable[Any]],
+) -> Any:
+    """
+    Invoke a tool via the next middleware and apply TOON encoding.
+
+    Args:
+        ctx: FastMCP context
+        tool_name: Name of the tool being invoked
+        args: Tool arguments
+        call_next: Next middleware in chain
+
+    Returns:
+        Tool result with TOON encoding applied when enabled
+    """
+    _ = (ctx, tool_name, args)
+    result = await call_next()
+    return _apply_toon_encoding(result)


### PR DESCRIPTION
### Motivation

- Centralize the pattern of invoking the next middleware and applying TOON output encoding into a single helper to remove duplication in governance paths and make future changes easier.
- Preserve existing governance semantics while keeping the encoding behavior identical to the previous inline logic.

### Description

- Add a new helper module `src/meta_mcp/tooling/invocation.py` that defines `invoke_tool(ctx, tool_name, args, call_next)` and a local `_apply_toon_encoding` which applies `TOON` encoding when enabled.
- Update `src/meta_mcp/middleware.py` to import `invoke_tool` and ` _apply_toon_encoding`, replace direct `await call_next()` + encoding call sites with `await invoke_tool(context, tool_name, arguments, call_next)`, and expose the imported `_apply_toon_encoding` as a static attribute to preserve the middleware API.
- Add package initializer `src/meta_mcp/tooling/__init__.py` for the new tooling helpers.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966ca8604748326872acf33c265532d)