### PR TITLE
Revalidate lease after inflight acquisition to prevent concurrent overuse

### DIFF
--- a/src/meta_mcp/middleware.py
+++ b/src/meta_mcp/middleware.py
@@ -711,6 +711,19 @@ class GovernanceMiddleware(Middleware):
                     f"Please request a new lease via get_tool_schema('{tool_name}')."
                 )
 
+            lease = await lease_manager.validate(client_id, tool_name)
+            if lease is None:
+                logger.warning(
+                    f"Lease invalidated before execution for {tool_name} "
+                    f"(client: {client_id}, session: {session_id})"
+                )
+                await lease_manager.release_inflight(client_id, tool_name)
+                inflight_acquired = False
+                raise ToolError(
+                    f"Lease exhausted for tool '{tool_name}'. "
+                    f"Please request a new lease via get_tool_schema('{tool_name}')."
+                )
+
         async def _execute_tool() -> Any:
             try:
                 result = await call_next()


### PR DESCRIPTION
### Motivation
- Fix a race where deferring lease consumption until after `call_next()` allowed parallel requests to both execute when only one call remained by ensuring the lease is still valid after acquiring an inflight slot.

### Description
- Add a post-`acquire_inflight` revalidation step that calls `lease_manager.validate(client_id, tool_name)` in `src/meta_mcp/middleware.py`.
- If revalidation returns `None`, call `lease_manager.release_inflight(client_id, tool_name)`, clear `inflight_acquired`, and raise a `ToolError` to prevent execution under an invalidated lease.
- Preserve the deferred consumption flow in `_execute_tool` which still calls `lease_manager.consume(...)` after successful `call_next()` and releases the inflight slot in the `finally` block.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69671bb4ecdc83268c045cfabc8b2818)