### PR TITLE
Fix inflight lease reservation concurrency

### DIFF
--- a/src/meta_mcp/middleware.py
+++ b/src/meta_mcp/middleware.py
@@ -699,7 +699,7 @@ class GovernanceMiddleware(Middleware):
                 )
 
             inflight_acquired = await lease_manager.acquire_inflight(
-                client_id, tool_name, lease.calls_remaining
+                client_id, tool_name
             )
             if not inflight_acquired:
                 logger.warning(


### PR DESCRIPTION
### Motivation
- Prevent lease overuse under concurrent calls by ensuring inflight slot acquisition observes the current lease `calls_remaining` atomically so two parallel requests cannot both proceed when only one call remains.
- The previous change deferred `consume()` until after tool execution which allowed a race where both requests validated the lease and executed the tool before consumption; this PR closes that gap at reservation time.

### Description
- Replace non-atomic `INCR`-based inflight reservation with a Redis `WATCH`/transactional pipeline that reads the lease, validates `calls_remaining`, compares against current inflight count, and increments the inflight counter atomically in `LeaseManager.acquire_inflight` (`src/meta_mcp/leases/manager.py`).
- Add `WatchError` handling and a bounded retry loop to handle contention and retries when watch conflicts occur.
- Update the middleware call site to the new `acquire_inflight(client_id, tool_name)` signature (`src/meta_mcp/middleware.py`).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69671cda04108326841755f0fd3d8b8c)