### PR TITLE
Harden inflight lease guards for concurrent calls

### DIFF
--- a/src/meta_mcp/middleware.py
+++ b/src/meta_mcp/middleware.py
@@ -699,7 +699,7 @@ class GovernanceMiddleware(Middleware):
                 )
 
             inflight_acquired = await lease_manager.acquire_inflight(
-                client_id, tool_name, lease.calls_remaining
+                client_id, tool_name
             )
             if not inflight_acquired:
                 logger.warning(


### PR DESCRIPTION
### Motivation
- Deferring lease consumption until after tool execution introduced a race where two concurrent callers could both pass validation and run a tool while only one call remained, allowing lease overuse and side effects. 
- Prevent concurrent executions from exceeding the live lease capacity by making inflight slot acquisition atomic against the current lease in Redis.

### Description
- Reworked `LeaseManager.acquire_inflight` to the signature `acquire_inflight(client_id, tool_id)` and implemented an atomic Redis Lua script that reads the lease JSON, verifies `calls_remaining`, increments the inflight counter, sets TTL on the inflight key, and rolls back/cleans up if the inflight count would exceed `calls_remaining`.
- Updated `src/meta_mcp/middleware.py` to call the new `acquire_inflight(client_id, tool_name)` API while preserving deferred `lease_manager.consume(...)` and the existing inflight release path.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69671ceaf8c483269d800d9e5b35446e)