### PR TITLE
Re-scope hooks: run before-tool hooks pre-governance and have invoke_tool only run after-tool hooks

### DIFF
--- a/src/meta_mcp/middleware.py
+++ b/src/meta_mcp/middleware.py
@@ -141,10 +141,13 @@ class GovernanceMiddleware(Middleware):
         *,
         tool_call: Optional[ToolCall] = None,
         run_context: Optional[RunContext] = None,
-        run_before_hooks: bool = True,
     ) -> Any:
         """
-        Invoke the next tool middleware with hook wrapping.
+        Invoke the next tool middleware with after-hook wrapping.
+
+        Note:
+            Callers must run before_tool hooks and any governance checks
+            before invoking this method.
 
         Args:
             context: FastMCP context
@@ -156,7 +159,6 @@ class GovernanceMiddleware(Middleware):
             Tool execution result
         """
         session_id = str(context.session_id)
-        hook_manager = get_hook_manager()
         if tool_call is None:
             tool_call = ToolCall(tool_name=tool_name, arguments=arguments)
         if run_context is None:
@@ -165,9 +167,6 @@ class GovernanceMiddleware(Middleware):
                 tool_name=tool_call.tool_name,
                 arguments=tool_call.arguments,
             )
-
-        if run_before_hooks:
-            tool_call = await hook_manager.before_tool(tool_call, run_context)
 
         if tool_call.tool_name != tool_name:
             context.request_context.tool_name = tool_call.tool_name
@@ -185,6 +184,7 @@ class GovernanceMiddleware(Middleware):
 
         result = await call_next()
         tool_result = ToolResult(tool_name=tool_call.tool_name, output=result)
+        hook_manager = get_hook_manager()
         tool_result = await hook_manager.after_tool(tool_result, run_context)
         return tool_result.output
 
@@ -875,7 +875,6 @@ class GovernanceMiddleware(Middleware):
                 arguments,
                 tool_call=tool_call,
                 run_context=run_context,
-                run_before_hooks=False,
             )
             return self._apply_toon_encoding(result)
 
@@ -889,7 +888,6 @@ class GovernanceMiddleware(Middleware):
                 arguments,
                 tool_call=tool_call,
                 run_context=run_context,
-                run_before_hooks=False,
             )
             return self._apply_toon_encoding(result)
 
@@ -933,7 +931,6 @@ class GovernanceMiddleware(Middleware):
                     arguments,
                     tool_call=tool_call,
                     run_context=run_context,
-                    run_before_hooks=False,
                 )
                 return self._apply_toon_encoding(result)
 
@@ -972,7 +969,6 @@ class GovernanceMiddleware(Middleware):
                     arguments,
                     tool_call=tool_call,
                     run_context=run_context,
-                    run_before_hooks=False,
                 )
                 return self._apply_toon_encoding(result)
             else:


### PR DESCRIPTION
### Motivation

- Fix a high-priority governance bypass where `before_tool` hooks could mutate `tool_name`/`arguments` after governance checks, allowing hooks to escalate or alter calls without re-evaluation or correct auditing. 
- Ensure governance decisions and auditing are computed against the post-`before_tool` call state by requiring before-hooks to run before any governance logic, and keep `invoke_tool` responsible only for after-hook wrapping.

### Description

- Removed the `run_before_hooks` parameter and the internal `before_tool` invocation from `GovernanceMiddleware.invoke_tool`, so it no longer runs pre-governance hooks. 
- Moved `get_hook_manager()` usage so `invoke_tool` only runs `after_tool` hooks and returns the post-hook output. 
- Updated callers in `on_call_tool` to invoke the helper that already runs `_run_before_tool_hooks` and to stop passing the removed flag, and clarified the `invoke_tool` docstring to state callers must run `before_tool` hooks and governance checks first. 
- Small refactor to keep context/request_context updates and `RunContext` creation intact while preventing late mutations from bypassing governance.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69671d6d7a908326a75e6353af3934b0)