### PR TITLE
Clarify package import for core tools server

### DIFF
--- a/servers/core_tools.py
+++ b/servers/core_tools.py
@@ -10,6 +10,7 @@ from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
 from loguru import logger
 
+# Import the installed package to keep server startup working in editable/wheel installs.
 from meta_mcp.config import Config
 
 


### PR DESCRIPTION
### Motivation
- Ensure `servers/core_tools.py` imports the installed package namespace so the server starts correctly in editable/wheel installs by avoiding `src.*`-style imports.

### Description
- Added an explanatory comment above the `from meta_mcp.config import Config` import in `servers/core_tools.py` to document that the installed `meta_mcp` package import is intentional and required for editable/wheel install scenarios.

### Testing
- No automated tests were executed for this change; the edit is a documentation/comment-only clarification and does not alter runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69671d90e284832686b428d972e0d7fe)