### PR TITLE
Fix core tools config import path usage

### DIFF
--- a/servers/core_tools.py
+++ b/servers/core_tools.py
@@ -10,7 +10,7 @@ from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
 from loguru import logger
 
-from meta_mcp.config import Config
+from meta_mcp import config as config_module
 
 
 # Create FastMCP server instance
@@ -30,7 +30,7 @@ def _validate_path(path: str) -> Path:
     Raises:
         ToolError: If path is outside WORKSPACE_ROOT
     """
-    workspace = Path(Config.WORKSPACE_ROOT).resolve()
+    workspace = Path(config_module.Config.WORKSPACE_ROOT).resolve()
     target = (workspace / path).resolve()
 
     # Check if target is within workspace using is_relative_to (Python 3.9+)
@@ -247,7 +247,7 @@ def execute_command(command: str, cwd: Optional[str] = None) -> str:
     """
     # Validate and resolve working directory
     if cwd is None:
-        work_dir = Path(Config.WORKSPACE_ROOT).resolve()
+        work_dir = Path(config_module.Config.WORKSPACE_ROOT).resolve()
     else:
         work_dir = _validate_path(cwd)
         if not work_dir.is_dir():
@@ -260,7 +260,7 @@ def execute_command(command: str, cwd: Optional[str] = None) -> str:
             cwd=str(work_dir),
             capture_output=True,
             text=True,
-            timeout=Config.COMMAND_TIMEOUT,
+            timeout=config_module.Config.COMMAND_TIMEOUT,
             encoding="utf-8",
             errors="replace",
         )
@@ -276,7 +276,7 @@ def execute_command(command: str, cwd: Optional[str] = None) -> str:
 
     except subprocess.TimeoutExpired:
         raise ToolError(
-            f"Command timed out after {Config.COMMAND_TIMEOUT} seconds: {command}"
+            f"Command timed out after {config_module.Config.COMMAND_TIMEOUT} seconds: {command}"
         )
     except Exception as e:
         raise ToolError(f"Failed to execute command: {e}")
@@ -302,7 +302,7 @@ async def git_commit(message: str, cwd: Optional[str] = None) -> str:
     """
     # Validate and resolve working directory
     if cwd is None:
-        work_dir = Path(Config.WORKSPACE_ROOT).resolve()
+        work_dir = Path(config_module.Config.WORKSPACE_ROOT).resolve()
     else:
         work_dir = _validate_path(cwd)
         if not work_dir.is_dir():
@@ -315,7 +315,7 @@ async def git_commit(message: str, cwd: Optional[str] = None) -> str:
             cwd=str(work_dir),
             capture_output=True,
             text=True,
-            timeout=Config.COMMAND_TIMEOUT,
+            timeout=config_module.Config.COMMAND_TIMEOUT,
             encoding="utf-8",
             errors="replace",
         )
@@ -333,7 +333,9 @@ async def git_commit(message: str, cwd: Optional[str] = None) -> str:
         return json.dumps(output, indent=2)
 
     except subprocess.TimeoutExpired:
-        raise ToolError(f"Git commit timed out after {Config.COMMAND_TIMEOUT}s")
+        raise ToolError(
+            f"Git commit timed out after {config_module.Config.COMMAND_TIMEOUT}s"
+        )
     except Exception as e:
         raise ToolError(f"Git commit error: {e}")
 
@@ -361,7 +363,7 @@ async def git_push(
     """
     # Validate and resolve working directory
     if cwd is None:
-        work_dir = Path(Config.WORKSPACE_ROOT).resolve()
+        work_dir = Path(config_module.Config.WORKSPACE_ROOT).resolve()
     else:
         work_dir = _validate_path(cwd)
         if not work_dir.is_dir():
@@ -379,7 +381,7 @@ async def git_push(
             cwd=str(work_dir),
             capture_output=True,
             text=True,
-            timeout=Config.COMMAND_TIMEOUT,
+            timeout=config_module.Config.COMMAND_TIMEOUT,
             encoding="utf-8",
             errors="replace",
         )
@@ -397,7 +399,9 @@ async def git_push(
         return json.dumps(output, indent=2)
 
     except subprocess.TimeoutExpired:
-        raise ToolError(f"Git push timed out after {Config.COMMAND_TIMEOUT}s")
+        raise ToolError(
+            f"Git push timed out after {config_module.Config.COMMAND_TIMEOUT}s"
+        )
     except Exception as e:
         raise ToolError(f"Git push error: {e}")
 
@@ -427,7 +431,7 @@ async def git_reset(
     """
     # Validate and resolve working directory
     if cwd is None:
-        work_dir = Path(Config.WORKSPACE_ROOT).resolve()
+        work_dir = Path(config_module.Config.WORKSPACE_ROOT).resolve()
     else:
         work_dir = _validate_path(cwd)
         if not work_dir.is_dir():
@@ -446,7 +450,7 @@ async def git_reset(
             cwd=str(work_dir),
             capture_output=True,
             text=True,
-            timeout=Config.COMMAND_TIMEOUT,
+            timeout=config_module.Config.COMMAND_TIMEOUT,
             encoding="utf-8",
             errors="replace",
         )
@@ -465,7 +469,9 @@ async def git_reset(
         return json.dumps(output, indent=2)
 
     except subprocess.TimeoutExpired:
-        raise ToolError(f"Git reset timed out after {Config.COMMAND_TIMEOUT}s")
+        raise ToolError(
+            f"Git reset timed out after {config_module.Config.COMMAND_TIMEOUT}s"
+        )
     except Exception as e:
         raise ToolError(f"Git reset error: {e}")
 


### PR DESCRIPTION
### Motivation
- Avoid runtime import failures when the project is installed (e.g., via `pip install -e .`) by ensuring the core tools server imports configuration through the installed package namespace rather than relying on repository-relative imports.

### Description
- Replaced `from meta_mcp.config import Config` with `from meta_mcp import config as config_module` in `servers/core_tools.py`.
- Qualified all references to `Config.WORKSPACE_ROOT` and `Config.COMMAND_TIMEOUT` as `config_module.Config.WORKSPACE_ROOT` and `config_module.Config.COMMAND_TIMEOUT` in `_validate_path`, `execute_command`, `git_commit`, `git_push`, and `git_reset`.
- Kept existing error messages and behavior unchanged; only the import and qualification were modified.
- Changes applied and committed to `servers/core_tools.py`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69671e8a0c00832694df270d7a500ccd)