### PR TITLE
Clarify package-safe import for core tools config

### DIFF
--- a/servers/core_tools.py
+++ b/servers/core_tools.py
@@ -10,6 +10,7 @@ from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
 from loguru import logger
 
+# Import from the installed package to avoid ModuleNotFoundError in packaged setups.
 from meta_mcp.config import Config
 
 


### PR DESCRIPTION
### Motivation
- Prevent `ModuleNotFoundError` in packaged installs by ensuring servers import `Config` from the installed package namespace rather than `src.meta_mcp`.

### Description
- Add a comment in `servers/core_tools.py` documenting the explicit import of `Config` from `meta_mcp.config` to emphasize package-safe imports.

### Testing
- No automated tests were run; this is a comment-only change and does not alter runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69671e86dc1883268216f3f2bf8a005a)