### PR TITLE
Harden inflight lease checks for concurrent tool calls

### DIFF
--- a/src/meta_mcp/middleware.py
+++ b/src/meta_mcp/middleware.py
@@ -699,7 +699,7 @@ class GovernanceMiddleware(Middleware):
                 )
 
             inflight_acquired = await lease_manager.acquire_inflight(
-                client_id, tool_name, lease.calls_remaining
+                client_id, tool_name
             )
             if not inflight_acquired:
                 logger.warning(


### PR DESCRIPTION
### Motivation
- Fix race where deferring lease `consume` until after `call_next()` allowed multiple concurrent invocations to pass validation and run the tool when only one call remained.
- Ensure inflight slot accounting cannot be bypassed by concurrent requests and that side effects are limited by the lease.

### Description
- Change `LeaseManager.acquire_inflight` signature to `async def acquire_inflight(self, client_id: str, tool_id: str) -> bool` and make it re-check the current lease after incrementing the inflight counter by calling `validate`, rejecting the acquisition if `inflight > lease.calls_remaining`.
- Update `middleware` to call `lease_manager.acquire_inflight(client_id, tool_name)` with the new signature and preserve deferred `consume` behavior and inflight release in the `_execute_tool` finally block.
- Keep existing inflight key TTL handling and cleanup logic while ensuring inflight counts are decremented and deleted if acquisition fails.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69671e7ad6dc8326880982b6b93f55cf)