### PR TITLE
Move search formatting into registry and add deprecation warnings for discovery

### DIFF
--- a/src/meta_mcp/registry/__init__.py
+++ b/src/meta_mcp/registry/__init__.py
@@ -1,5 +1,11 @@
 """Tool registry package."""
 from .models import ServerRecord, ToolCandidate, ToolRecord
-from .registry import tool_registry
+from .registry import format_search_results, tool_registry
 
-__all__ = ["tool_registry", "ToolRecord", "ServerRecord", "ToolCandidate"]
+__all__ = [
+    "format_search_results",
+    "tool_registry",
+    "ToolRecord",
+    "ServerRecord",
+    "ToolCandidate",
+]

--- a/src/meta_mcp/registry/registry.py
+++ b/src/meta_mcp/registry/registry.py
@@ -11,7 +11,7 @@ class ToolRegistry:
     """
     Static tool registry loaded from YAML.
 
-    Replaces the dynamic discovery.ToolRegistry for Phase 1+.
+    config/tools.yaml is the single source of truth for tool definitions.
 
     Features:
     - Static tool definitions from YAML
@@ -29,7 +29,7 @@ class ToolRegistry:
     @classmethod
     def from_yaml(cls, yaml_path: str) -> "ToolRegistry":
         """
-        Load registry from YAML file.
+        Load registry from YAML file (config/tools.yaml is canonical).
 
         Args:
             yaml_path: Path to tools.yaml configuration file
@@ -208,3 +208,37 @@ _default_tools_path = os.getenv("TOOLS_YAML_PATH") or str(
     Path(__file__).parent.parent.parent / "config" / "tools.yaml"
 )
 tool_registry = ToolRegistry.from_yaml(_default_tools_path)
+
+
+def format_search_results(results: List[ToolCandidate]) -> str:
+    """
+    Format search results for agent consumption.
+
+    Returns ONLY:
+    - Tool name
+    - One-sentence description
+    - Sensitivity flag
+
+    Does NOT include:
+    - Arguments or schemas
+    - Examples or usage hints
+    - Recommendations or rankings
+
+    Args:
+        results: List of ToolCandidate objects
+
+    Returns:
+        Formatted string with minimal metadata
+    """
+    if not results:
+        return "No tools found matching your query."
+
+    lines = [f"Found {len(results)} tool(s):\n"]
+
+    for tool in results:
+        sensitivity = "[SAFE]" if tool.risk_level == "safe" else "[SENSITIVE]"
+        lines.append(f"• {tool.tool_id} {sensitivity}")
+        lines.append(f"  {tool.description_1line}")
+        lines.append("")  # Blank line between tools
+
+    return "\n".join(lines).strip()

--- a/src/meta_mcp/supervisor.py
+++ b/src/meta_mcp/supervisor.py
@@ -17,13 +17,12 @@ from servers.core_tools import core_server
 
 from .audit import audit_logger
 from .config import Config
-from .discovery import format_search_results
 from .governance.approval import get_approval_provider
 from .governance.artifacts import get_artifact_generator
 from .governance.policy import evaluate_policy
 from .governance.tokens import generate_token
 from .leases import lease_manager
-from .registry import tool_registry
+from .registry import format_search_results, tool_registry
 from .middleware import GovernanceMiddleware
 from .state import governance_state
 from .validation import run_all_validations
@@ -165,7 +164,7 @@ async def lifespan(app):
 
     Startup:
     1. Redis connectivity verification (graceful degradation to PERMISSION mode)
-    2. Core tools registration in discovery registry
+    2. Tool registry loaded from config/tools.yaml
     3. Workspace directory creation
     4. Compliance validations (bootstrap tools, progressive discovery)
     5. Approval provider health check
@@ -190,8 +189,7 @@ async def lifespan(app):
         # governance_state.get_mode() already handles fail-safe to PERMISSION
         # No need to crash - system will operate in PERMISSION mode
 
-    # 2. Register core tools in discovery registry
-    # (Already done via auto-registration in discovery.py on import)
+    # 2. Tool registry loaded from config/tools.yaml (single source of truth)
     all_tools = tool_registry.get_all_summaries()
     logger.info(f"Tool registry initialized with {len(all_tools)} tools")
 


### PR DESCRIPTION
### Motivation
- Centralize search-result formatting with the canonical YAML-backed tool registry and treat `config/tools.yaml` as the single source of truth.
- Make the legacy in-memory discovery registry an explicit compatibility shim that emits deprecation warnings to encourage migration to the new registry.

### Description
- Moved `format_search_results()` into `src/meta_mcp/registry/registry.py` and re-exported it from `src/meta_mcp/registry/__init__.py` so callers can import `meta_mcp.registry.format_search_results`.
- Updated `src/meta_mcp/supervisor.py` to import `format_search_results` and `tool_registry` from `meta_mcp.registry` instead of `meta_mcp.discovery`.
- Removed the standalone `formatting.py` module and replaced the legacy implementation in `src/meta_mcp/discovery.py` with a lightweight, deprecated `ToolRegistry` shim that warns on use and retains minimal API (`ToolSummary`, `tool_registry`) for backward compatibility.
- Updated documentation strings and lifecycle comments to call out `config/tools.yaml` as the canonical tool definition source.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966c3ae0c6c83268f7326e4bd9e81e9)