### PR TITLE
Return structured command results; add command runner and config options

### DIFF
--- a/servers/core_tools.py
+++ b/servers/core_tools.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import json
-import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -12,10 +11,13 @@ from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
 from loguru import logger
 
+from meta_mcp.command_runner import run_command
+from meta_mcp.config import Config
+
 
 # Constants
-WORKSPACE_ROOT = os.getenv("WORKSPACE_ROOT", "./workspace")
-COMMAND_TIMEOUT = 30
+WORKSPACE_ROOT = Config.WORKSPACE_ROOT
+COMMAND_TIMEOUT = Config.COMMAND_TIMEOUT_SECONDS
 
 
 # Create FastMCP server instance
@@ -239,7 +241,7 @@ def remove_directory(path: str) -> str:
 
 
 @core_server.tool()
-def execute_command(command: str, cwd: Optional[str] = None) -> str:
+def execute_command(command: str, cwd: Optional[str] = None) -> dict:
     """
     Execute shell command with timeout.
 
@@ -248,7 +250,7 @@ def execute_command(command: str, cwd: Optional[str] = None) -> str:
         cwd: Working directory (relative to workspace root, default: workspace root)
 
     Returns:
-        Command output (stdout + stderr)
+        Structured command result (stdout, stderr, exit code, policy decision)
     """
     # Validate and resolve working directory
     if cwd is None:
@@ -259,30 +261,14 @@ def execute_command(command: str, cwd: Optional[str] = None) -> str:
             raise ToolError(f"Working directory is not a directory: {cwd}")
 
     try:
-        result = subprocess.run(
-            command,
-            shell=True,
-            cwd=str(work_dir),
-            capture_output=True,
-            text=True,
+        result = run_command(
+            command=command,
+            cwd=work_dir,
             timeout=COMMAND_TIMEOUT,
-            encoding="utf-8",
-            errors="replace",
+            allow_patterns=Config.COMMAND_ALLOW_PATTERNS,
+            deny_patterns=Config.COMMAND_DENY_PATTERNS,
         )
-
-        output = []
-        if result.stdout:
-            output.append(f"STDOUT:\n{result.stdout}")
-        if result.stderr:
-            output.append(f"STDERR:\n{result.stderr}")
-        output.append(f"Exit code: {result.returncode}")
-
-        return "\n\n".join(output) if output else "Command produced no output"
-
-    except subprocess.TimeoutExpired:
-        raise ToolError(
-            f"Command timed out after {COMMAND_TIMEOUT} seconds: {command}"
-        )
+        return result.to_dict()
     except Exception as e:
         raise ToolError(f"Failed to execute command: {e}")
 

--- a/src/meta_mcp/command_runner.py
+++ b/src/meta_mcp/command_runner.py
@@ -1,0 +1,159 @@
+"""Command execution with allow/deny policy enforcement."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import re
+import subprocess
+from typing import Iterable, Optional
+
+from loguru import logger
+
+
+@dataclass(frozen=True)
+class CommandPolicyDecision:
+    """Result of command policy evaluation."""
+
+    allowed: bool
+    reason: str
+    matched_pattern: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    """Normalized command execution result."""
+
+    command: str
+    cwd: str
+    allowed: bool
+    policy_reason: str
+    matched_pattern: Optional[str]
+    stdout: str
+    stderr: str
+    exit_code: Optional[int]
+    timed_out: bool
+
+    def to_dict(self) -> dict:
+        return {
+            "command": self.command,
+            "cwd": self.cwd,
+            "allowed": self.allowed,
+            "policy_reason": self.policy_reason,
+            "matched_pattern": self.matched_pattern,
+            "stdout": self.stdout,
+            "stderr": self.stderr,
+            "exit_code": self.exit_code,
+            "timed_out": self.timed_out,
+        }
+
+
+def _match_pattern(command: str, patterns: Iterable[str]) -> Optional[str]:
+    for pattern in patterns:
+        if re.search(pattern, command):
+            return pattern
+    return None
+
+
+def evaluate_command_policy(
+    command: str, allow_patterns: Iterable[str], deny_patterns: Iterable[str]
+) -> CommandPolicyDecision:
+    """Evaluate command against allow/deny patterns."""
+    deny_match = _match_pattern(command, deny_patterns)
+    if deny_match:
+        return CommandPolicyDecision(
+            allowed=False,
+            reason="Command denied by policy.",
+            matched_pattern=deny_match,
+        )
+
+    allow_patterns_list = list(allow_patterns)
+    if allow_patterns_list:
+        allow_match = _match_pattern(command, allow_patterns_list)
+        if allow_match:
+            return CommandPolicyDecision(
+                allowed=True,
+                reason="Command allowed by policy.",
+                matched_pattern=allow_match,
+            )
+        return CommandPolicyDecision(
+            allowed=False,
+            reason="Command not in allow list.",
+            matched_pattern=None,
+        )
+
+    return CommandPolicyDecision(
+        allowed=True,
+        reason="Command allowed (no allow list configured).",
+        matched_pattern=None,
+    )
+
+
+def run_command(
+    command: str,
+    cwd: Path,
+    timeout: int,
+    allow_patterns: Iterable[str],
+    deny_patterns: Iterable[str],
+) -> CommandResult:
+    """Execute a command with policy enforcement and normalized output."""
+    policy = evaluate_command_policy(command, allow_patterns, deny_patterns)
+    logger.info(
+        "Command policy decision | allowed={} reason={} matched_pattern={} command={}",
+        policy.allowed,
+        policy.reason,
+        policy.matched_pattern,
+        command,
+    )
+
+    if not policy.allowed:
+        return CommandResult(
+            command=command,
+            cwd=str(cwd),
+            allowed=False,
+            policy_reason=policy.reason,
+            matched_pattern=policy.matched_pattern,
+            stdout="",
+            stderr="",
+            exit_code=None,
+            timed_out=False,
+        )
+
+    try:
+        result = subprocess.run(
+            command,
+            shell=True,
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            encoding="utf-8",
+            errors="replace",
+        )
+        return CommandResult(
+            command=command,
+            cwd=str(cwd),
+            allowed=True,
+            policy_reason=policy.reason,
+            matched_pattern=policy.matched_pattern,
+            stdout=result.stdout or "",
+            stderr=result.stderr or "",
+            exit_code=result.returncode,
+            timed_out=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        logger.warning(
+            "Command timed out after {}s | command={}",
+            timeout,
+            command,
+        )
+        return CommandResult(
+            command=command,
+            cwd=str(cwd),
+            allowed=True,
+            policy_reason=policy.reason,
+            matched_pattern=policy.matched_pattern,
+            stdout=exc.stdout or "",
+            stderr=exc.stderr or "",
+            exit_code=None,
+            timed_out=True,
+        )


### PR DESCRIPTION
### Motivation
- Provide a centralized, auditable command execution path that enforces allow/deny policies and returns a normalized, structured result for callers.
- Move command-related configuration (timeout and allow/deny patterns) into `Config` so behavior can be tuned via environment variables.

### Description
- Update `servers/core_tools.py` to use `run_command` and `Config` by importing `meta_mcp.command_runner.run_command` and `meta_mcp.config.Config`, replace inline `subprocess.run` logic, and return the structured result via `result.to_dict()` from `execute_command` (signature changed to return `dict`).
- Add `src/meta_mcp/command_runner.py` implementing `CommandPolicyDecision`, `CommandResult`, `_match_pattern`, `evaluate_command_policy`, and `run_command` which enforce allow/deny regex patterns, log policy decisions, handle timeouts, and normalize `stdout`, `stderr`, `exit_code`, and `timed_out` fields.
- Extend `src/meta_mcp/config.py` with helper `_parse_list`, configuration entries `COMMAND_TIMEOUT_SECONDS`, `COMMAND_ALLOW_PATTERNS`, and `COMMAND_DENY_PATTERNS`, and add validation for the timeout and regex patterns in `Config.validate()`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966c4537be88326ad7a8748d5814f5f)