### PR TITLE
Consume leases before execution and refund on failure (minimal changes)

### DIFF
--- a/src/meta_mcp/middleware.py
+++ b/src/meta_mcp/middleware.py
@@ -653,6 +653,7 @@ class GovernanceMiddleware(Middleware):
         client_id = None
 
         inflight_acquired = False
+        consumed_lease = None
 
         if Config.ENABLE_LEASE_MANAGEMENT and tool_name not in bootstrap_tools:
             # Extract client_id from FastMCP session context
@@ -711,26 +712,31 @@ class GovernanceMiddleware(Middleware):
                     f"Please request a new lease via get_tool_schema('{tool_name}')."
                 )
 
+            consumed_lease = await lease_manager.consume(client_id, tool_name)
+            if consumed_lease is None:
+                logger.warning(
+                    f"Failed to consume lease for {tool_name} "
+                    f"(client: {client_id}, session: {session_id})"
+                )
+                if inflight_acquired:
+                    await lease_manager.release_inflight(client_id, tool_name)
+                raise ToolError(
+                    f"Lease exhausted for tool '{tool_name}'. "
+                    f"Please request a new lease via get_tool_schema('{tool_name}')."
+                )
+
         async def _execute_tool() -> Any:
             try:
                 result = await call_next()
-                if should_consume_lease and client_id is not None:
-                    consumed_lease = await lease_manager.consume(client_id, tool_name)
-                    if consumed_lease is None:
-                        logger.warning(
-                            f"Failed to consume lease for {tool_name} "
-                            f"(client: {client_id}, session: {session_id})"
-                        )
-                        raise ToolError(
-                            f"Lease exhausted for tool '{tool_name}'. "
-                            f"Please request a new lease via get_tool_schema('{tool_name}')."
-                        )
-
-                    logger.info(
-                        f"Lease consumed for {tool_name} "
-                        f"(client: {client_id}, remaining={consumed_lease.calls_remaining})"
-                    )
                 return self._apply_toon_encoding(result)
+            except Exception:
+                if (
+                    should_consume_lease
+                    and client_id is not None
+                    and consumed_lease is not None
+                ):
+                    await lease_manager.refund_call(consumed_lease)
+                raise
             finally:
                 if should_consume_lease and client_id is not None and inflight_acquired:
                     await lease_manager.release_inflight(client_id, tool_name)


### PR DESCRIPTION
### Motivation
- Prevent a race where concurrent requests can pass validation and run a tool while only one call remained by consuming a lease prior to execution and restoring it on failure. 
- Make the fix minimal to avoid broad redesign and preserve existing inflight concurrency controls and validation/token checks. 

### Description
- Middleware now calls `lease_manager.consume(client_id, tool_name)` immediately after acquiring an inflight slot and stores the returned `consumed_lease` for potential refund. 
- On tool execution failure the middleware calls `lease_manager.refund_call(consumed_lease)` to restore the consumed call, and always releases the inflight slot in a `finally` block. 
- Added a `refund_call` helper to `LeaseManager` that restores one call back to the lease in Redis while respecting TTL and expiry semantics. 
- Preserved upfront `lease_manager.validate` and capability token checks, and continued use of `acquire_inflight`/`release_inflight` for concurrency control. 

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69671fd580788326a6f96f624498994c)