### PR TITLE
Fix lease reservation to prevent concurrent overuse

### DIFF
--- a/src/meta_mcp/middleware.py
+++ b/src/meta_mcp/middleware.py
@@ -653,6 +653,7 @@ class GovernanceMiddleware(Middleware):
         client_id = None
 
         inflight_acquired = False
+        reserved_lease = None
 
         if Config.ENABLE_LEASE_MANAGEMENT and tool_name not in bootstrap_tools:
             # Extract client_id from FastMCP session context
@@ -712,25 +713,34 @@ class GovernanceMiddleware(Middleware):
                 )
 
         async def _execute_tool() -> Any:
+            nonlocal reserved_lease
             try:
-                result = await call_next()
                 if should_consume_lease and client_id is not None:
-                    consumed_lease = await lease_manager.consume(client_id, tool_name)
-                    if consumed_lease is None:
+                    reserved_lease_local = await lease_manager.reserve_call(
+                        client_id, tool_name
+                    )
+                    if reserved_lease_local is None:
                         logger.warning(
-                            f"Failed to consume lease for {tool_name} "
+                            f"Failed to reserve lease for {tool_name} "
                             f"(client: {client_id}, session: {session_id})"
                         )
                         raise ToolError(
                             f"Lease exhausted for tool '{tool_name}'. "
                             f"Please request a new lease via get_tool_schema('{tool_name}')."
                         )
+                    reserved_lease = reserved_lease_local
 
-                    logger.info(
-                        f"Lease consumed for {tool_name} "
-                        f"(client: {client_id}, remaining={consumed_lease.calls_remaining})"
-                    )
+                result = await call_next()
                 return self._apply_toon_encoding(result)
+            except Exception:
+                if should_consume_lease and reserved_lease is not None:
+                    restored = await lease_manager.restore_call(reserved_lease)
+                    if not restored:
+                        logger.error(
+                            f"Failed to restore lease for {tool_name} "
+                            f"(client: {client_id}, session: {session_id})"
+                        )
+                raise
             finally:
                 if should_consume_lease and client_id is not None and inflight_acquired:
                     await lease_manager.release_inflight(client_id, tool_name)


### PR DESCRIPTION
### Motivation
- The previous change deferred lease consumption until after `call_next()` to avoid decrementing on failed tool runs, but this allowed concurrent requests to both pass `validate()` and execute when only one call remained, causing lease overuse.

### Description
- Add `reserve_call` and `restore_call` to `LeaseManager` to perform an atomic reservation using Redis `WATCH`/pipeline with retries and TTL handling.
- Update the governance middleware to call `lease_manager.reserve_call()` before `call_next()`, store the returned reservation in `reserved_lease`, and call `lease_manager.restore_call()` if execution raises, while still releasing inflight slots in the `finally` block.
- Preserve the existing `consume` method for explicit consumption semantics and add logging for reservation and restore failures to aid diagnostics.
- Keep inflight acquisition/release behavior unchanged to maintain concurrent-slot tracking.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696789a592848326aa98d0f771633b6d)