### PR TITLE
Re-evaluate governance after hook-mutated tool calls

### DIFF
--- a/src/meta_mcp/middleware.py
+++ b/src/meta_mcp/middleware.py
@@ -775,11 +775,21 @@ class GovernanceMiddleware(Middleware):
         """
         tool_name = context.request_context.tool_name
         arguments = context.request_context.arguments or {}
+        original_tool_name = tool_name
+        original_arguments = arguments
         tool_call, run_context = await self._run_before_tool_hooks(
             context, tool_name, arguments
         )
         tool_name = tool_call.tool_name
         arguments = tool_call.arguments
+        if (
+            tool_name != original_tool_name
+            or arguments != original_arguments
+        ):
+            logger.info(
+                "before_tool hook mutated tool call; "
+                "re-evaluating governance against updated tool call"
+            )
         session_id = str(context.session_id)
 
         # PHASE 3+4 INTEGRATION: Validate lease and token before governance checks


### PR DESCRIPTION
### Motivation

- Ensure governance is evaluated against the effective tool invocation when `before_tool` hooks are allowed to mutate the call so hooks cannot silently bypass checks or produce misleading audit context.

### Description

- Capture the original `tool_name` and `arguments` before running `before_tool` hooks and compare them to the effective `tool_call`; if mutated, log an explicit info message indicating governance will be re-evaluated against the updated values (added `original_tool_name`, `original_arguments`, and the mutation check in `on_call_tool`).

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696789c210a08326acadd5786520cf4b)