### PR TITLE
Preserve TF-IDF vocab cache when clearing embeddings

### DIFF
--- a/src/meta_mcp/retrieval/embedder.py
+++ b/src/meta_mcp/retrieval/embedder.py
@@ -240,4 +240,4 @@ class ToolEmbedder:
     def clear_cache(self) -> None:
         """Clear embedding cache."""
         self._cache.clear()
-        self._vocab_list.clear()  # Clear cached sorted vocabulary (PERF-001)
+        # Keep _vocab_list in sync with _vocabulary/_idf_scores; rebuild via build_index().


### PR DESCRIPTION
### Motivation
- Fix a bug where `clear_cache()` removed the cached sorted vocabulary (`_vocab_list`) which led to stale IDF scores and zero vectors on subsequent embedding regeneration.

### Description
- Removed the `self._vocab_list.clear()` call from `ToolEmbedder.clear_cache()` and added a comment that vocabulary/IDF state should be rebuilt via `build_index()`; change made in `src/meta_mcp/retrieval/embedder.py` at `clear_cache()`.

### Testing
- Ran `pytest tests/test_embedder.py::test_cache_functionality -v` and `pytest tests/test_semantic_search.py -v`, both failed to start due to `ModuleNotFoundError: No module named 'redis'` raised in `tests/conftest.py:12`, so automated tests could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69697e56c35883269e91d47dff5e7ff2)