### PR TITLE
Use canonical `tool_id` in end-to-end tests and clarify ToolCandidate comments

### DIFF
--- a/src/meta_mcp/registry/models.py
+++ b/src/meta_mcp/registry/models.py
@@ -92,11 +92,11 @@ class ToolCandidate:
     Model must call get_tool_schema() to access a tool.
     """
 
-    tool_id: str
+    tool_id: str  # Canonical identifier (also exposed via .name for compatibility)
     server_id: str
-    description_1line: str
+    description_1line: str  # 1-line summary (also exposed via .description for compatibility)
     tags: list[str]
-    risk_level: str
+    risk_level: str  # "safe", "sensitive", "dangerous" (also exposed via .sensitive)
     relevance_score: float = 0.0  # Semantic similarity (Phase 2)
     allowed_in_mode: AllowedInMode = AllowedInMode.ALLOWED
     schema_hint: str | None = None  # Brief parameter summary

--- a/tests/integration/test_end_to_end_scenario.py
+++ b/tests/integration/test_end_to_end_scenario.py
@@ -46,8 +46,8 @@ async def test_complete_safe_tool_workflow(redis_client):
     results = tool_registry.search("read")
     assert len(results) > 0
 
-    # Step 2: Find read_file
-    read_file = next((t for t in results if t.name == "read_file"), None)
+    # Step 2: Find read_file (use canonical tool_id instead of compatibility name)
+    read_file = next((t for t in results if t.tool_id == "read_file"), None)
     assert read_file is not None
     assert read_file.sensitive is False  # Safe tool
 
@@ -85,8 +85,8 @@ async def test_complete_sensitive_tool_workflow(redis_client):
     results = tool_registry.search("write")
     assert len(results) > 0
 
-    # Step 2: Find write_file
-    write_file = next((t for t in results if t.name == "write_file"), None)
+    # Step 2: Find write_file (use canonical tool_id instead of compatibility name)
+    write_file = next((t for t in results if t.tool_id == "write_file"), None)
     assert write_file is not None
     assert write_file.sensitive is True  # Sensitive tool
 


### PR DESCRIPTION
### Motivation
- Make tests use the canonical `tool_id` field and document compatibility accessors on `ToolCandidate` to reduce reliance on deprecated attribute usage and clarify intent.

### Description
- Update `ToolCandidate` field comments in `src/meta_mcp/registry/models.py` to note that `tool_id`, `description_1line`, and `risk_level` are the canonical fields and are also exposed via compatibility accessors (`.name`, `.description`, `.sensitive`).
- Replace `.name` lookups with `tool_id` in `tests/integration/test_end_to_end_scenario.py` to use the canonical identifier in end-to-end integration tests.

### Testing
- Ran `pytest tests/integration/test_end_to_end_scenario.py -v --tb=short`, which aborted during test collection with `ModuleNotFoundError: No module named 'redis'` originating from `tests/conftest.py`, so test execution could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69699c2891d88326a8624a4908c36c22)