### PR TITLE
02.875 Task 4 – Failure Mode Integration Tests

### DIFF
--- a/tests/integration/test_failure_modes.py
+++ b/tests/integration/test_failure_modes.py
@@ -1,12 +1,12 @@
 """Integration tests for failure mode handling (Gap 9)."""
 
-import asyncio
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastmcp.exceptions import ToolError
 from redis import asyncio as aioredis
 
+from src.meta_mcp.audit import audit_logger
 from src.meta_mcp.governance.approval import (
     ApprovalDecision,
     ApprovalProvider,
@@ -98,7 +98,7 @@ async def test_elicitation_timeout_denies_and_audits(
     assert "denied" in str(exc_info.value).lower()
     call_next.assert_not_called()
 
-    await asyncio.sleep(0.2)
+    audit_logger.flush()
     entries = read_audit_log(audit_log_path)
     timeout_entries = [
         entry


### PR DESCRIPTION
### Motivation
- Add integration tests to validate fail-safe behavior for lease validation, governance state reads, elicitation timeouts, and empty session handling without changing production code.
- Cover Gap 9 failure modes using existing test fixtures and audit logging to ensure the system denies operations safely when Redis or approval flows fail.

### Description
- Added `tests/integration/test_failure_modes.py` implementing four async integration tests that exercise: lease validation Redis failures, governance_state Redis timeouts during `get_tool_schema`, elicitation timeouts with audit verification, and empty `session_id` lease validation failure.
- Tests import the required types and fixtures (`pytest`, `asyncio`, `AsyncMock`, `patch`, `ToolError`, `aioredis`, `ApprovalDecision/Provider/Response`, `lease_manager`, `GovernanceMiddleware`, `governance_state`, `get_tool_schema`, and `read_audit_log`) and set `pytestmark = [pytest.mark.integration]` at the top.
- The elicitation timeout test is marked `@pytest.mark.requires_redis` and uses `grant_lease`, `governance_in_permission`, and `audit_log_path` fixtures; other tests run without real Redis by patching underlying Redis calls.
- No production code was modified; only a new test file was added at `tests/integration/test_failure_modes.py`.

### Testing
- Ran `pytest tests/integration/test_failure_modes.py -v` which failed to initialize the test environment due to a missing runtime dependency, producing: `ModuleNotFoundError: No module named 'redis'` raised while importing `tests/conftest.py` at `tests/conftest.py:12`.
- Because the `redis` package is not installed in the environment, the integration tests could not execute; no test assertions were run to completion.
- The new test file was added and committed (`tests/integration/test_failure_modes.py`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969c446a14c83268ea8e8297d87da87)