### PR TITLE
Fix Redis `.close()` deprecation, use timezone-aware datetimes, and fix async `scan_iter` test mock

### DIFF
--- a/src/meta_mcp/rag/context_pack/builder.py
+++ b/src/meta_mcp/rag/context_pack/builder.py
@@ -12,7 +12,7 @@ import json
 import logging
 import uuid
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -154,7 +154,7 @@ class ContextPack:
     @property
     def is_expired(self) -> bool:
         """Check if the pack has expired."""
-        return datetime.utcnow() > self.expires_at
+        return datetime.now(timezone.utc) > self.expires_at
 
     @property
     def selected_count(self) -> int:
@@ -286,7 +286,7 @@ class ContextPackBuilder:
 
         # Generate pack ID and timestamps
         pack_id = str(uuid.uuid4())
-        created_at = datetime.utcnow()
+        created_at = datetime.now(timezone.utc)
         ttl = ttl_seconds if ttl_seconds is not None else self._default_ttl_seconds
         expires_at = created_at + timedelta(seconds=ttl)
 

--- a/src/meta_mcp/rag/context_pack/validator.py
+++ b/src/meta_mcp/rag/context_pack/validator.py
@@ -11,7 +11,7 @@ import hmac
 import json
 import logging
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 
 from .builder import ContextPack
@@ -128,7 +128,7 @@ class ContextPackValidator:
             ValidationResult with validation status and any error message
         """
         self._validations_performed += 1
-        validated_at = datetime.utcnow()
+        validated_at = datetime.now(timezone.utc)
 
         logger.debug(f"Validating ContextPack: pack_id={pack.pack_id}")
 
@@ -239,7 +239,7 @@ class ContextPackValidator:
         Returns:
             True if current time is past expires_at, False otherwise
         """
-        return datetime.utcnow() > pack.expires_at
+        return datetime.now(timezone.utc) > pack.expires_at
 
     def time_until_expiration(self, pack: ContextPack) -> float | None:
         """
@@ -251,7 +251,7 @@ class ContextPackValidator:
         Returns:
             Seconds until expiration, or None if already expired
         """
-        remaining = (pack.expires_at - datetime.utcnow()).total_seconds()
+        remaining = (pack.expires_at - datetime.now(timezone.utc)).total_seconds()
         return remaining if remaining > 0 else None
 
     def get_metrics(self) -> dict:

--- a/src/meta_mcp/redis_client.py
+++ b/src/meta_mcp/redis_client.py
@@ -145,7 +145,7 @@ async def get_redis_client() -> aioredis.Redis:
                     exc,
                 )
                 if _redis_client is not None:
-                    await _redis_client.close()
+                    await _redis_client.aclose()
                     _redis_client = None
                 if _redis_pool is not None:
                     await _redis_pool.disconnect()
@@ -183,7 +183,7 @@ async def close_redis_client() -> None:
 
     if _redis_client is not None:
         try:
-            await _redis_client.close()
+            await _redis_client.aclose()
         except RuntimeError as exc:
             logger.warning("Redis client close skipped: {}", exc)
         _redis_client = None

--- a/tests/test_context_pack.py
+++ b/tests/test_context_pack.py
@@ -1,6 +1,6 @@
 """Tests for ContextPack builder and validator modules."""
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
 import pytest
@@ -64,8 +64,8 @@ class TestContextPack:
             explainer_output={"explanation": "test"},
             token_budget={"total_budget": 8000, "used_by_selection": 100, "available_for_generation": 7900},
             signature="abcd1234",
-            created_at=datetime.utcnow(),
-            expires_at=datetime.utcnow() + timedelta(minutes=5),
+            created_at=datetime.now(timezone.utc),
+            expires_at=datetime.now(timezone.utc) + timedelta(minutes=5),
         )
 
     def test_to_dict(self):
@@ -112,8 +112,8 @@ class TestContextPack:
             explainer_output={},
             token_budget={},
             signature="sig",
-            created_at=datetime.utcnow() - timedelta(hours=1),
-            expires_at=datetime.utcnow() - timedelta(minutes=5),
+            created_at=datetime.now(timezone.utc) - timedelta(hours=1),
+            expires_at=datetime.now(timezone.utc) - timedelta(minutes=5),
         )
         
         assert pack.is_expired is True
@@ -428,7 +428,7 @@ class TestValidationResult:
             is_valid=True,
             status=ValidationStatus.VALID,
             error_message="",
-            validated_at=datetime.utcnow(),
+            validated_at=datetime.now(timezone.utc),
         )
         
         result_dict = result.to_dict()

--- a/tests/test_lease_manager_coverage.py
+++ b/tests/test_lease_manager_coverage.py
@@ -368,7 +368,11 @@ class TestLeaseManagerPurgeExpired:
     async def test_purge_expired_redis_error(self):
         manager = LeaseManager()
         mock_redis = AsyncMock()
-        mock_redis.scan_iter = AsyncMock(side_effect=Exception("connection lost"))
+        async def failing_scan_iter(*args, **kwargs):
+            raise Exception("connection lost")
+            yield
+
+        mock_redis.scan_iter = failing_scan_iter
 
         with patch.object(manager, "_get_redis", return_value=mock_redis):
             count = await manager.purge_expired()


### PR DESCRIPTION
### Motivation
- Remove deprecation warnings from the async Redis client shutdown calls and make pack expiration checks timezone-aware to avoid future errors on Python 3.12+.\
- Prevent an unawaited-coroutine `RuntimeWarning` from tests that mock `scan_iter` by ensuring the mock yields via a real async generator.\
- Keep tests that compare datetimes working by making all relevant timestamps timezone-aware (UTC).\

### Description
- Replaced `await _redis_client.close()` with `await _redis_client.aclose()` in the shared client lifecycle and shutdown path in `src/meta_mcp/redis_client.py`.\
- Replaced `datetime.utcnow()` with `datetime.now(timezone.utc)` and added `timezone` imports in `src/meta_mcp/rag/context_pack/builder.py` and `src/meta_mcp/rag/context_pack/validator.py` so expiration checks and created/validated timestamps are timezone-aware.\
- Updated tests in `tests/test_context_pack.py` to use `datetime.now(timezone.utc)` for created/validated timestamps to remain consistent with the code changes.\
- Fixed test mocking in `tests/test_lease_manager_coverage.py` so `mock_redis.scan_iter` is an async generator (`failing_scan_iter`) instead of an `AsyncMock` with a `side_effect`, preventing unawaited coroutine runtime warnings when iterating results in `purge_expired`.\

### Testing
- Ran `uv run pytest tests/test_context_pack.py -q -W error::DeprecationWarning` and the suite passed (`34 passed`).\
- Ran `uv run pytest tests/test_redis_pooling.py tests/test_lease_manager.py -q -W error::DeprecationWarning`; Redis-dependent tests were skipped in this environment (skipped tests reported), and no deprecation warnings were raised.\
- Ran `uv run pytest tests/test_lease_manager_coverage.py tests/test_lease_manager.py -q -W error::RuntimeWarning` and the suites passed in this environment (tests passed with some Redis-dependent tests skipped), and the `RuntimeWarning` from the mocked `scan_iter` was resolved.\
- Ran `uv run ruff check ...` to surface lint issues; `ruff` reported multiple existing repository lint violations that were not introduced by these changes (the check was executed but reported pre-existing issues).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a61aafe9b4832baddeff564300c059)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes Redis deprecation warnings and makes expiration checks UTC-aware. Also fixes a test to avoid an unawaited coroutine RuntimeWarning.

- **Bug Fixes**
  - Use Redis aclose() in client lifecycle and shutdown to remove deprecation warnings.
  - Switch to datetime.now(timezone.utc) for created_at, expires_at, and validated_at; update builder, validator, and tests so comparisons are timezone-aware.
  - Replace mocked scan_iter with a real async generator that raises, preventing RuntimeWarning during purge_expired.

<sup>Written for commit 1ce4105a232aca7b96a3097d9693fbf4eaea4cc9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed timestamp consistency to ensure accurate time-based operations across the platform.

* **Tests**
  * Enhanced test coverage for asynchronous operations and error handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->