### PR TITLE
Remove agent-callable governance override tools from MCP surface

### DIFF
--- a/config/tools.yaml
+++ b/config/tools.yaml
@@ -18,14 +18,12 @@ servers:
   description: Core file, system, and git operations
   risk_level: dangerous
   tags:
-  - command
   - commit
   - core
   - create
   - delete
   - directory
   - discovery
-  - execute
   - file
   - get
   - git
@@ -42,7 +40,6 @@ servers:
   - admin
   - get
   - governance
-  - set
 tools:
 - tool_id: read_file
   server_id: core_tools
@@ -158,21 +155,6 @@ tools:
   required_scopes:
   - tool:remove_directory
   - filesystem:delete
-- tool_id: execute_command
-  server_id: core_tools
-  description_1line: Execute shell command with timeout.
-  description_full: 'Execute shell command with timeout.
-
-    Runs command in workspace directory with 30-second timeout. Returns stdout, stderr, and exit code.'
-  tags:
-  - core
-  - execute
-  - command
-  risk_level: sensitive
-  requires_permission: true
-  required_scopes:
-  - tool:execute_command
-  - system:execute
 - tool_id: search_tools
   server_id: core_tools
   description_1line: Search for available tools by name or description.
@@ -235,36 +217,6 @@ tools:
   - vcs:git
   - vcs:write
   - network:remote
-- tool_id: git_reset
-  server_id: core_tools
-  description_1line: Reset git repository to a specific state.
-  description_full: 'Reset git repository to a specific state.
-
-    Resets the repository to specified commit or state. Can be destructive - use with caution.'
-  tags:
-  - git
-  risk_level: dangerous
-  requires_permission: true
-  required_scopes:
-  - tool:git_reset
-  - vcs:git
-  - vcs:destructive
-- tool_id: set_governance_mode
-  server_id: admin_tools
-  description_1line: Set the governance execution mode.
-  description_full: 'Set the governance execution mode.
-
-    Switches between READ_ONLY, PERMISSION, and BYPASS modes. Affects all subsequent tool calls.'
-  tags:
-  - admin
-  - set
-  - governance
-  risk_level: sensitive
-  requires_permission: true
-  required_scopes:
-  - tool:set_governance_mode
-  - admin:governance
-  - admin:configure
 - tool_id: get_governance_status
   server_id: admin_tools
   description_1line: Get current governance mode and state.
@@ -280,18 +232,3 @@ tools:
   required_scopes:
   - tool:get_governance_status
   - admin:read
-- tool_id: revoke_all_elevations
-  server_id: admin_tools
-  description_1line: Revoke all active governance elevations.
-  description_full: 'Revoke all active governance elevations.
-
-    Clears all temporary permission grants. Resets all tools to base governance policy.'
-  tags:
-  - admin
-  - governance
-  risk_level: dangerous
-  requires_permission: true
-  required_scopes:
-  - tool:revoke_all_elevations
-  - admin:governance
-  - admin:security

--- a/servers/admin_tools.py
+++ b/servers/admin_tools.py
@@ -1,91 +1,21 @@
-"""Admin tools for MetaMCP governance control.
+"""Admin tools for MetaMCP governance visibility.
 
-These tools ARE registered in the tool registry (config/tools.yaml) and follow
-standard governance policy based on each tool's risk_level:
-- get_governance_status is safe (allowed in READ_ONLY/PERMISSION/BYPASS)
-- set_governance_mode is sensitive (approval in PERMISSION, blocked in READ_ONLY)
-- revoke_all_elevations is dangerous (approval in PERMISSION, blocked in READ_ONLY)
-
-Tools:
-- set_governance_mode: Change execution mode
-- get_governance_status: Query current mode and state
-- revoke_all_elevations: Clear all scoped elevations
+Registered admin tools:
+- get_governance_status: Query current mode and state (read-only)
 """
 
 from fastmcp import FastMCP
-from fastmcp.exceptions import ToolError
 from loguru import logger
 
 # Import governance components using package-safe absolute imports
 # Note: Requires package installation via 'pip install -e .'
-from meta_mcp.audit import AuditEvent, audit_logger
+from meta_mcp.audit import audit_logger
 from meta_mcp.middleware import SENSITIVE_TOOLS
 from meta_mcp.registry import tool_registry
-from meta_mcp.state import ExecutionMode, governance_state
+from meta_mcp.state import governance_state
 
 # Create FastMCP server instance for admin tools
 admin_server = FastMCP("AdminTools")
-
-
-@admin_server.tool()
-async def set_governance_mode(mode: str) -> str:
-    """
-    Set the global governance mode.
-
-    ADMIN TOOL: This tool controls the governance system itself.
-    Always requires approval in PERMISSION mode.
-
-    Args:
-        mode: Governance mode to set (read_only, permission, bypass)
-
-    Returns:
-        Confirmation message with old and new modes
-
-    Raises:
-        ToolError: If mode is invalid or Redis update fails
-    """
-    # Validate mode is a valid ExecutionMode
-    try:
-        new_mode = ExecutionMode(mode.lower())
-    except ValueError:
-        valid_modes = [m.value for m in ExecutionMode]
-        raise ToolError(f"Invalid mode '{mode}'. Valid modes: {', '.join(valid_modes)}")
-
-    # Get current mode for audit trail
-    try:
-        old_mode = await governance_state.get_mode()
-    except Exception as e:
-        logger.error(f"Failed to get current governance mode: {e}")
-        raise ToolError(f"Failed to get current mode: {e}")
-
-    # Don't change if already in requested mode
-    if old_mode == new_mode:
-        return f"Governance mode is already set to '{new_mode.value}'"
-
-    # Set new mode
-    try:
-        success = await governance_state.set_mode(new_mode)
-        if not success:
-            raise ToolError("Failed to set governance mode in Redis")
-    except Exception as e:
-        logger.error(f"Failed to set governance mode: {e}")
-        raise ToolError(f"Failed to set mode: {e}")
-
-    # Audit the mode change
-    audit_logger.log_mode_change(
-        old_mode=old_mode.value,
-        new_mode=new_mode.value,
-        changed_by="admin_tool",
-    )
-
-    logger.warning(f"Governance mode changed: {old_mode.value} → {new_mode.value}")
-
-    return (
-        f"Governance mode changed successfully:\n"
-        f"  Previous: {old_mode.value}\n"
-        f"  Current:  {new_mode.value}\n\n"
-        f"This change affects all subsequent tool invocations."
-    )
 
 
 @admin_server.tool()
@@ -155,63 +85,3 @@ async def get_governance_status() -> str:
     ]
 
     return "\n".join(status_lines)
-
-
-@admin_server.tool()
-async def revoke_all_elevations() -> str:
-    """
-    Revoke all active scoped elevations.
-
-    This forces all subsequent sensitive operations to request new approval,
-    even if they were previously elevated.
-
-    ADMIN TOOL: Use with caution. This affects all sessions.
-
-    Returns:
-        Count of elevations revoked
-
-    Raises:
-        ToolError: If Redis operation fails
-    """
-    try:
-        redis = await governance_state._get_redis()
-
-        # Use SCAN to find all elevation keys (cursor-based iteration)
-        elevation_keys = []
-        cursor = 0
-
-        while True:
-            cursor, keys = await redis.scan(cursor=cursor, match="elevation:*", count=100)
-            elevation_keys.extend(keys)
-
-            # cursor == 0 means we've completed the iteration
-            if cursor == 0:
-                break
-
-        # Delete all elevation keys
-        if elevation_keys:
-            deleted = await redis.delete(*elevation_keys)
-            logger.warning(f"Revoked {deleted} elevation(s) via admin tool")
-
-            # Audit the revocation
-            audit_logger.log(
-                AuditEvent.ELEVATIONS_REVOKED,
-                action="revoke_all_elevations",
-                count=deleted,
-                changed_by="admin_tool",
-            )
-
-            return (
-                f"Successfully revoked {deleted} active elevation(s).\n\n"
-                f"All subsequent sensitive operations will require new approval."
-            )
-        logger.info("No active elevations to revoke")
-        return "No active elevations found."
-
-    except Exception as e:
-        logger.error(f"Failed to revoke elevations: {e}")
-        raise ToolError(f"Failed to revoke elevations: {e}")
-
-
-# Export admin server for mounting
-__all__ = ["admin_server"]

--- a/servers/core_tools.py
+++ b/servers/core_tools.py
@@ -236,53 +236,6 @@ def remove_directory(path: str) -> str:
 
 
 @core_server.tool()
-def execute_command(command: str, cwd: str | None = None) -> str:
-    """
-    Execute shell command with timeout.
-
-    Args:
-        command: Shell command to execute
-        cwd: Working directory (relative to workspace root, default: workspace root)
-
-    Returns:
-        Command output (stdout + stderr)
-    """
-    # Validate and resolve working directory
-    if cwd is None:
-        work_dir = Path(WORKSPACE_ROOT).resolve()
-    else:
-        work_dir = _validate_path(cwd)
-        if not work_dir.is_dir():
-            raise ToolError(f"Working directory is not a directory: {cwd}")
-
-    try:
-        result = subprocess.run(
-            command,
-            shell=True,
-            cwd=str(work_dir),
-            capture_output=True,
-            text=True,
-            timeout=COMMAND_TIMEOUT,
-            encoding="utf-8",
-            errors="replace",
-        )
-
-        output = []
-        if result.stdout:
-            output.append(f"STDOUT:\n{result.stdout}")
-        if result.stderr:
-            output.append(f"STDERR:\n{result.stderr}")
-        output.append(f"Exit code: {result.returncode}")
-
-        return "\n\n".join(output) if output else "Command produced no output"
-
-    except subprocess.TimeoutExpired:
-        raise ToolError(f"Command timed out after {COMMAND_TIMEOUT} seconds: {command}")
-    except Exception as e:
-        raise ToolError(f"Failed to execute command: {e}")
-
-
-@core_server.tool()
 async def git_commit(message: str, cwd: str | None = None) -> str:
     """
     Commit staged changes to git repository.
@@ -401,71 +354,6 @@ async def git_push(
     except Exception as e:
         raise ToolError(f"Git push error: {e}")
 
-
-@core_server.tool()
-async def git_reset(ref: str = "HEAD", hard: bool = False, cwd: str | None = None) -> str:
-    """
-    Reset git repository to a specific commit.
-
-    WARNING: --hard flag will discard all uncommitted changes!
-
-    Args:
-        ref: Git reference (commit SHA, branch, tag, default: "HEAD")
-        hard: If True, discard all changes (--hard reset)
-        cwd: Working directory (defaults to WORKSPACE_ROOT)
-
-    Returns:
-        Reset output
-
-    Raises:
-        ToolError: If git reset fails or path validation fails
-
-    Example:
-        git_reset("HEAD~1", hard=True, "/workspace/myproject")
-    """
-    # Validate and resolve working directory
-    if cwd is None:
-        work_dir = Path(WORKSPACE_ROOT).resolve()
-    else:
-        work_dir = _validate_path(cwd)
-        if not work_dir.is_dir():
-            raise ToolError(f"Working directory is not a directory: {cwd}")
-
-    # Build git reset command
-    cmd = ["git", "reset"]
-    if hard:
-        cmd.append("--hard")
-    cmd.append(ref)
-
-    # Execute git reset
-    try:
-        result = subprocess.run(
-            cmd,
-            cwd=str(work_dir),
-            capture_output=True,
-            text=True,
-            timeout=COMMAND_TIMEOUT,
-            encoding="utf-8",
-            errors="replace",
-        )
-
-        output = {
-            "exit_code": result.returncode,
-            "stdout": result.stdout,
-            "stderr": result.stderr,
-        }
-
-        if result.returncode != 0:
-            raise ToolError(f"Git reset failed: {result.stderr}")
-
-        reset_type = "--hard" if hard else "--soft"
-        logger.warning(f"Git reset {reset_type} to {ref} in {work_dir}")
-        return json.dumps(output, indent=2)
-
-    except subprocess.TimeoutExpired:
-        raise ToolError(f"Git reset timed out after {COMMAND_TIMEOUT}s")
-    except Exception as e:
-        raise ToolError(f"Git reset error: {e}")
 
 
 # Export server for mounting

--- a/src/config/tools.yaml
+++ b/src/config/tools.yaml
@@ -18,14 +18,12 @@ servers:
   description: Core file, system, and git operations
   risk_level: dangerous
   tags:
-  - command
   - commit
   - core
   - create
   - delete
   - directory
   - discovery
-  - execute
   - file
   - get
   - git
@@ -42,7 +40,6 @@ servers:
   - admin
   - get
   - governance
-  - set
 tools:
 - tool_id: read_file
   server_id: core_tools
@@ -158,21 +155,6 @@ tools:
   required_scopes:
   - tool:remove_directory
   - filesystem:delete
-- tool_id: execute_command
-  server_id: core_tools
-  description_1line: Execute shell command with timeout.
-  description_full: 'Execute shell command with timeout.
-
-    Runs command in workspace directory with 30-second timeout. Returns stdout, stderr, and exit code.'
-  tags:
-  - core
-  - execute
-  - command
-  risk_level: sensitive
-  requires_permission: true
-  required_scopes:
-  - tool:execute_command
-  - system:execute
 - tool_id: search_tools
   server_id: core_tools
   description_1line: Search for available tools by name or description.
@@ -235,36 +217,6 @@ tools:
   - vcs:git
   - vcs:write
   - network:remote
-- tool_id: git_reset
-  server_id: core_tools
-  description_1line: Reset git repository to a specific state.
-  description_full: 'Reset git repository to a specific state.
-
-    Resets the repository to specified commit or state. Can be destructive - use with caution.'
-  tags:
-  - git
-  risk_level: dangerous
-  requires_permission: true
-  required_scopes:
-  - tool:git_reset
-  - vcs:git
-  - vcs:destructive
-- tool_id: set_governance_mode
-  server_id: admin_tools
-  description_1line: Set the governance execution mode.
-  description_full: 'Set the governance execution mode.
-
-    Switches between READ_ONLY, PERMISSION, and BYPASS modes. Affects all subsequent tool calls.'
-  tags:
-  - admin
-  - set
-  - governance
-  risk_level: sensitive
-  requires_permission: true
-  required_scopes:
-  - tool:set_governance_mode
-  - admin:governance
-  - admin:configure
 - tool_id: get_governance_status
   server_id: admin_tools
   description_1line: Get current governance mode and state.
@@ -280,18 +232,3 @@ tools:
   required_scopes:
   - tool:get_governance_status
   - admin:read
-- tool_id: revoke_all_elevations
-  server_id: admin_tools
-  description_1line: Revoke all active governance elevations.
-  description_full: 'Revoke all active governance elevations.
-
-    Clears all temporary permission grants. Resets all tools to base governance policy.'
-  tags:
-  - admin
-  - governance
-  risk_level: dangerous
-  requires_permission: true
-  required_scopes:
-  - tool:revoke_all_elevations
-  - admin:governance
-  - admin:security

--- a/src/meta_mcp/middleware.py
+++ b/src/meta_mcp/middleware.py
@@ -38,14 +38,10 @@ SENSITIVE_TOOLS = {
     "create_directory",
     "remove_directory",
     # Command execution
-    "execute_command",
     # Git operations
     "git_commit",
     "git_push",
-    "git_reset",
     # Admin operations
-    "set_governance_mode",
-    "revoke_all_elevations",
 }
 
 ELICITATION_TIMEOUT = Config.ELICITATION_TIMEOUT
@@ -99,7 +95,7 @@ class GovernanceMiddleware(Middleware):
             arguments: Tool arguments
 
         Returns:
-            Context key (path for file ops, command[:50] for commands)
+            Context key (path for file and directory ops, cwd for git ops)
         """
         # Move operation: use source path (MUST check BEFORE general file ops)
         if tool_name == "move_file":
@@ -117,18 +113,9 @@ class GovernanceMiddleware(Middleware):
         if tool_name in {"create_directory", "remove_directory", "list_directory"}:
             return arguments.get("path", "unknown")
 
-        # Command execution: use first 50 chars of command
-        if tool_name == "execute_command":
-            command = arguments.get("command", "unknown")
-            return command[:50] if len(command) > 50 else command
-
         # Git operations: use current directory
         if tool_name.startswith("git_"):
             return arguments.get("cwd", ".")
-
-        # Admin operations: use operation name
-        if tool_name in {"set_governance_mode", "revoke_all_elevations"}:
-            return tool_name
 
         # Default: tool name
         return tool_name
@@ -274,13 +261,6 @@ class GovernanceMiddleware(Middleware):
                 base_scopes.append(f"resource:path:{source}")
             if dest:
                 base_scopes.append(f"resource:path:{dest}")
-
-        elif tool_name == "execute_command":
-            command = arguments.get("command", "")
-            if command:
-                # Add specific command being executed (first 50 chars)
-                cmd_preview = command[:50] if len(command) > 50 else command
-                base_scopes.append(f"resource:command:{cmd_preview}")
 
         elif tool_name in {"create_directory", "list_directory", "remove_directory"}:
             path = arguments.get("path", "")

--- a/src/meta_mcp/supervisor.py
+++ b/src/meta_mcp/supervisor.py
@@ -78,16 +78,12 @@ async def _get_tool_function(tool_name: str) -> Any | None:
         "create_directory",
         "remove_directory",
         "move_file",
-        "execute_command",
         "git_commit",
         "git_push",
-        "git_reset",
     }
 
     admin_tools = {
-        "set_governance_mode",
         "get_governance_status",
-        "revoke_all_elevations",
     }
 
     # Try to get FunctionTool from core_server
@@ -267,19 +263,17 @@ mcp = FastMCP(name=SERVER_NAME, middleware=[GovernanceMiddleware()], lifespan=li
 # context minimization principles. Tools will be registered dynamically via
 # progressive discovery as they are requested.
 #
-# Previously auto-exposed tools (13 total):
-# - core_server (10): read_file, write_file, delete_file, list_directory,
-#                     create_directory, move_file, execute_command,
-#                     git_commit, git_push, git_reset
-# - admin_server (3): set_governance_mode, get_governance_status,
-#                     revoke_all_elevations
+# Previously auto-exposed tools (9 total):
+# - core_server (8): read_file, write_file, delete_file, list_directory,
+#                    create_directory, move_file, git_commit, git_push
+# - admin_server (1): get_governance_status
 #
 # Tools will now be exposed on-demand via _expose_tool() function below.
 # ============================================================================
 
 # DEPRECATED: Auto-exposure via mount() - DO NOT UNCOMMENT
-# mcp.mount(core_server)   # Would expose all 10 core tools immediately
-# mcp.mount(admin_server)  # Would expose all 3 admin tools immediately
+# mcp.mount(core_server)   # Would expose all 8 core tools immediately
+# mcp.mount(admin_server)  # Would expose all 1 admin tools immediately
 
 
 # ============================================================================

--- a/tests/test_admin_tools.py
+++ b/tests/test_admin_tools.py
@@ -8,4 +8,4 @@ def test_admin_tools_docstring_mentions_registry():
     doc = admin_tools.__doc__ or ""
     assert "registered" in doc.lower()
     assert "governance" in doc.lower()
-    assert "read_only" in doc.lower()
+    assert "read-only" in doc.lower() or "read_only" in doc.lower()

--- a/tests/test_batch_search.py
+++ b/tests/test_batch_search.py
@@ -185,9 +185,13 @@ class TestBatchSearch:
 
         queries = ["file", "network", "email", "disk"]
 
-        start = time.perf_counter()
-        results = batch_search_tools(sample_registry, queries)
-        batch_time = time.perf_counter() - start
+        with patch(
+            "src.meta_mcp.registry.registry._resolve_governance_mode",
+            return_value=ExecutionMode.PERMISSION,
+        ):
+            start = time.perf_counter()
+            results = batch_search_tools(sample_registry, queries)
+            batch_time = time.perf_counter() - start
 
         # Should complete in reasonable time
         assert batch_time < 1.0  # Less than 1 second for small dataset

--- a/tests/test_coverage_completion.py
+++ b/tests/test_coverage_completion.py
@@ -30,13 +30,13 @@ def _mock_elicit_with_scopes(required_scopes):
 
 @pytest.mark.asyncio
 @pytest.mark.requires_redis
-async def test_execute_command_context_key_truncation(
+async def test_git_commit_context_key_uses_cwd(
     governance_in_permission,
     mock_fastmcp_context,
     grant_lease,
 ):
     """
-    Test that execute_command context key is truncated to 50 chars.
+    Test that git_commit context key uses cwd argument.
 
     Expected: Long commands should be truncated for context key
     Coverage: middleware.py lines 84-86
@@ -45,12 +45,12 @@ async def test_execute_command_context_key_truncation(
 
     # Setup with long command (>50 chars)
     long_command = "a" * 100
-    mock_fastmcp_context.request_context.tool_name = "execute_command"
+    mock_fastmcp_context.request_context.tool_name = "git_commit"
     mock_fastmcp_context.request_context.arguments = {"command": long_command}
     mock_fastmcp_context.request_context.session_id = "test-session"
-    await grant_lease(client_id="test-session", tool_name="execute_command")
+    await grant_lease(client_id="test-session", tool_name="git_commit")
     required_scopes = middleware._get_required_scopes(
-        "execute_command", mock_fastmcp_context.request_context.arguments
+        "git_commit", mock_fastmcp_context.request_context.arguments
     )
     mock_fastmcp_context.elicit = _mock_elicit_with_scopes(required_scopes)
 
@@ -131,38 +131,6 @@ async def test_git_operations_context_key(
     call_next.assert_called_once()
 
 
-@pytest.mark.asyncio
-@pytest.mark.requires_redis
-async def test_admin_operations_context_key(
-    governance_in_permission,
-    mock_fastmcp_context,
-    grant_lease,
-):
-    """
-    Test that admin operations use tool name as context key.
-
-    Expected: set_governance_mode, revoke_all_elevations use tool_name
-    Coverage: middleware.py lines 93-94
-    """
-    middleware = GovernanceMiddleware()
-
-    # Test set_governance_mode
-    mock_fastmcp_context.request_context.tool_name = "set_governance_mode"
-    mock_fastmcp_context.request_context.arguments = {"mode": "READ_ONLY"}
-    mock_fastmcp_context.request_context.session_id = "test-session"
-    await grant_lease(client_id="test-session", tool_name="set_governance_mode")
-    required_scopes = middleware._get_required_scopes(
-        "set_governance_mode", mock_fastmcp_context.request_context.arguments
-    )
-    mock_fastmcp_context.elicit = _mock_elicit_with_scopes(required_scopes)
-
-    call_next = AsyncMock(return_value="Mode changed")
-
-    # Execute
-    await middleware.on_call_tool(mock_fastmcp_context, call_next)
-
-    # Verify execution succeeded
-    call_next.assert_called_once()
 
 
 # ============================================================================

--- a/tests/test_progressive_discovery.py
+++ b/tests/test_progressive_discovery.py
@@ -91,7 +91,16 @@ async def test_get_tool_schema_triggers_exposure():
     read_file_preexposed = "read_file" in tool_names_before
 
     # Request schema for read_file (triggers exposure)
-    schema_result = await get_tool_schema.fn(tool_name="read_file")
+    with (
+        patch.object(
+            governance_state, "get_mode", new=AsyncMock(return_value=ExecutionMode.BYPASS)
+        ),
+        patch(
+            "src.meta_mcp.supervisor.lease_manager.grant",
+            AsyncMock(return_value=MagicMock()),
+        ),
+    ):
+        schema_result = await get_tool_schema.fn(tool_name="read_file")
 
     # Verify schema was returned
     assert "read_file" in schema_result, "Schema should contain tool name"
@@ -247,7 +256,7 @@ async def test_context_reduction_calculation():
     reduction_percentage = ((total_registered - initially_exposed) / total_registered) * 100
 
     # Verify metrics
-    assert total_registered >= 13, f"Expected at least 13 total tools, got {total_registered}"
+    assert total_registered >= 12, f"Expected at least 13 total tools, got {total_registered}"
 
     assert initially_exposed == 2, f"Expected 2 bootstrap tools, got {initially_exposed}"
 
@@ -273,14 +282,14 @@ async def test_discovery_workflow_complete():
     This simulates the expected model behavior with progressive discovery.
     """
     # Step 1: Model searches for tools
-    search_result = search_tools.fn(query="execute")
-    assert "execute_command" in search_result, "Search should find execute_command"
+    search_result = search_tools.fn(query="git")
+    assert "git_commit" in search_result, "Search should find git_commit"
 
-    # Verify execute_command not yet exposed
+    # Verify git_commit not yet exposed
     tools_after_search = await mcp.get_tools()
     names_after_search = [t.name for t in tools_after_search.values()]
-    assert "execute_command" not in names_after_search, (
-        "execute_command should not be exposed after search"
+    assert "git_commit" not in names_after_search, (
+        "git_commit should not be exposed after search"
     )
 
     # Step 2: Model requests schema
@@ -293,21 +302,21 @@ async def test_discovery_workflow_complete():
             AsyncMock(return_value=MagicMock()),
         ),
     ):
-        schema_result = await get_tool_schema.fn(tool_name="execute_command")
-    assert "execute_command" in schema_result, "Schema should be returned"
+        schema_result = await get_tool_schema.fn(tool_name="git_commit")
+    assert "git_commit" in schema_result, "Schema should be returned"
 
     # Verify execute_command now exposed
     tools_after_schema = await mcp.get_tools()
     names_after_schema = [t.name for t in tools_after_schema.values()]
-    assert "execute_command" in names_after_schema, (
-        "execute_command should be exposed after schema request"
+    assert "git_commit" in names_after_schema, (
+        "git_commit should be exposed after schema request"
     )
 
     # Step 3: Model can now invoke the tool
     # (We won't actually execute a command, just verify it's callable)
-    tool = await mcp.get_tool("execute_command")
+    tool = await mcp.get_tool("git_commit")
     assert tool is not None, "Tool should be retrievable after exposure"
-    assert tool.name == "execute_command", "Tool name should match"
+    assert tool.name == "git_commit", "Tool name should match"
 
 
 @pytest.mark.asyncio
@@ -325,10 +334,8 @@ async def test_no_breaking_changes():
         "list_directory",
         "create_directory",
         "move_file",
-        "execute_command",
         "git_commit",
         "git_push",
-        "git_reset",
     ]
 
     with (
@@ -373,5 +380,14 @@ async def test_bootstrap_tools_always_available():
     search_result = search_tools.fn(query="test")
     assert search_result is not None, "search_tools should be callable"
 
-    schema_result = await get_tool_schema.fn(tool_name="search_tools")
+    with (
+        patch.object(
+            governance_state, "get_mode", new=AsyncMock(return_value=ExecutionMode.BYPASS)
+        ),
+        patch(
+            "src.meta_mcp.supervisor.lease_manager.grant",
+            AsyncMock(return_value=MagicMock()),
+        ),
+    ):
+        schema_result = await get_tool_schema.fn(tool_name="search_tools")
     assert "search_tools" in schema_result, "get_tool_schema should be callable"

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -11,7 +11,8 @@ def test_registry_loads_from_yaml():
     assert tool_registry.is_registered("read_file")
     assert tool_registry.is_registered("write_file")
     assert tool_registry.is_registered("git_commit")
-    assert tool_registry.is_registered("set_governance_mode")
+    for removed in ["set_governance_mode", "revoke_all_elevations", "execute_command", "git_reset"]:
+        assert not tool_registry.is_registered(removed)
 
 
 def test_bootstrap_tools_defined():
@@ -83,7 +84,7 @@ def test_get_tool_not_found():
 def test_all_tools_have_required_fields():
     """All tools should have required metadata fields."""
     summaries = tool_registry.get_all_summaries()
-    assert len(summaries) >= 15  # Total tools from YAML (may grow over time)
+    assert len(summaries) >= 12  # Total tools from YAML (may grow over time)
 
     for tool in summaries:
         assert tool.tool_id

--- a/tests/test_retrieval_performance.py
+++ b/tests/test_retrieval_performance.py
@@ -10,10 +10,12 @@ Tests:
 
 import os
 import time
+from unittest.mock import patch
 
 import pytest
 
 from src.meta_mcp.registry.models import ToolRecord
+from src.meta_mcp.state import ExecutionMode
 from src.meta_mcp.retrieval.embedder import ToolEmbedder
 from src.meta_mcp.retrieval.search import SemanticSearch
 
@@ -63,41 +65,45 @@ class TestRetrievalPerformance:
         searcher = SemanticSearch(large_registry)
         max_latency_ms = float(os.getenv("SEARCH_LATENCY_BUDGET_MS", "250"))
 
-        # Warm up - build index
-        searcher.search("test")
+        with patch(
+            "src.meta_mcp.state.governance_state.get_mode",
+            return_value=ExecutionMode.PERMISSION,
+        ):
+            # Warm up - build index
+            searcher.search("test")
 
-        # Measure search time
-        queries = [
-            "read files from disk",
-            "network operations",
-            "database queries",
-            "encrypt data",
-            "process images",
-        ]
+            # Measure search time
+            queries = [
+                "read files from disk",
+                "network operations",
+                "database queries",
+                "encrypt data",
+                "process images",
+            ]
 
-        total_time = 0
-        iterations = len(queries)
+            total_time = 0
+            iterations = len(queries)
 
-        for query in queries:
-            start = time.perf_counter()
-            results = searcher.search(query)
-            end = time.perf_counter()
+            for query in queries:
+                start = time.perf_counter()
+                results = searcher.search(query)
+                end = time.perf_counter()
 
-            search_time_ms = (end - start) * 1000
-            total_time += search_time_ms
+                search_time_ms = (end - start) * 1000
+                total_time += search_time_ms
 
-            # Individual search should be under budget
-            assert search_time_ms < max_latency_ms, (
-                f"Search for '{query}' took {search_time_ms:.2f}ms, expected <{max_latency_ms:.0f}ms"
+                # Individual search should be under budget
+                assert search_time_ms < max_latency_ms, (
+                    f"Search for '{query}' took {search_time_ms:.2f}ms, expected <{max_latency_ms:.0f}ms"
+                )
+
+            # Average should be under budget
+            avg_time = total_time / iterations
+            assert avg_time < max_latency_ms, (
+                f"Average search time {avg_time:.2f}ms, expected <{max_latency_ms:.0f}ms"
             )
 
-        # Average should be under budget
-        avg_time = total_time / iterations
-        assert avg_time < max_latency_ms, (
-            f"Average search time {avg_time:.2f}ms, expected <{max_latency_ms:.0f}ms"
-        )
-
-        print(f"\nSearch performance: {avg_time:.2f}ms average over {iterations} queries")
+            print(f"\nSearch performance: {avg_time:.2f}ms average over {iterations} queries")
 
     def test_index_building_performance(self, large_registry):
         """Test index building completes in reasonable time."""
@@ -269,14 +275,18 @@ class TestRetrievalPerformance:
             "text processing",
         ]
 
-        start = time.perf_counter()
+        with patch(
+            "src.meta_mcp.state.governance_state.get_mode",
+            return_value=ExecutionMode.PERMISSION,
+        ):
+            start = time.perf_counter()
 
-        # Sequential searches (simulating concurrent workload)
-        for _ in range(5):  # 5 rounds
-            for query in queries:
-                searcher.search(query)
+            # Sequential searches (simulating concurrent workload)
+            for _ in range(5):  # 5 rounds
+                for query in queries:
+                    searcher.search(query)
 
-        end = time.perf_counter()
+            end = time.perf_counter()
 
         total_searches = 5 * len(queries)
         avg_time_ms = ((end - start) / total_searches) * 1000

--- a/tests/test_todo_list_2.py
+++ b/tests/test_todo_list_2.py
@@ -786,9 +786,9 @@ def test_admin_tools_imports_without_syspath():
 
         # Verify imports are successful
         assert hasattr(admin_tools, "admin_server")
-        assert hasattr(admin_tools, "set_governance_mode")
+        assert not hasattr(admin_tools, "set_governance_mode")
         assert hasattr(admin_tools, "get_governance_status")
-        assert hasattr(admin_tools, "revoke_all_elevations")
+        assert not hasattr(admin_tools, "revoke_all_elevations")
 
         # Verify sys.path was not mutated during import
         assert sys.path == original_syspath, "sys.path was mutated during import"
@@ -829,13 +829,7 @@ def test_admin_tools_governance_components_accessible():
     Validates: Imports resolve to actual usable objects
     """
     try:
-        from servers.admin_tools import (
-            AuditEvent,
-            ExecutionMode,
-            admin_server,
-            audit_logger,
-            governance_state,
-        )
+        from servers.admin_tools import admin_server, audit_logger, governance_state
 
         # Verify audit_logger has expected methods
         assert hasattr(audit_logger, "log_mode_change")
@@ -845,13 +839,6 @@ def test_admin_tools_governance_components_accessible():
         assert hasattr(governance_state, "get_mode")
         assert hasattr(governance_state, "set_mode")
 
-        # Verify ExecutionMode enum
-        assert hasattr(ExecutionMode, "PERMISSION")
-        assert hasattr(ExecutionMode, "READ_ONLY")
-        assert hasattr(ExecutionMode, "BYPASS")
-
-        # Verify AuditEvent enum
-        assert hasattr(AuditEvent, "ELEVATIONS_REVOKED")
 
     except ImportError as e:
         pytest.fail(f"Failed to import governance components from admin_tools: {e}")
@@ -970,8 +957,8 @@ async def test_todo_list_2_integration(mock_fastmcp_context):
     assert "[SENSITIVE]" in formatted  # remove_directory is sensitive
 
     # 5. Verify admin_tools imports work
-    from servers.admin_tools import admin_server, set_governance_mode
+    from servers.admin_tools import admin_server, get_governance_status
 
     assert admin_server is not None
-    assert hasattr(set_governance_mode, "fn")
-    assert callable(set_governance_mode.fn)
+    assert hasattr(get_governance_status, "fn")
+    assert callable(get_governance_status.fn)


### PR DESCRIPTION
Superseded by #224 which was merged. Both PRs were identical in scope (removing set_governance_mode, revoke_all_elevations, execute_command, git_reset) — #224 was selected for slightly cleaner imports and more targeted perf test patching.