### PR TITLE
Add per-session governance keys for secure mode changes

### DIFF
--- a/src/meta_mcp/audit.py
+++ b/src/meta_mcp/audit.py
@@ -31,6 +31,10 @@ class AuditEvent(str, Enum):
     SCOPED_ELEVATION_GRANTED = "scoped_elevation_granted"
     ELEVATIONS_REVOKED = "elevations_revoked"
     MODE_CHANGED = "mode_changed"
+    GOVERNANCE_MODE_CHANGE = "governance_mode_change"
+    GOVERNANCE_MODE_CHANGE_DENIED = "governance_mode_change_denied"
+    GOVERNANCE_KEY_INVALID = "governance_key_invalid"
+    GOVERNANCE_KEY_ROTATED = "governance_key_rotated"
     BLOCKED_READ_ONLY = "blocked_read_only"
     BYPASS_EXECUTED = "bypass_executed"
 

--- a/src/meta_mcp/config.py
+++ b/src/meta_mcp/config.py
@@ -138,6 +138,8 @@ class Config:
     # ========================================================================
     # Governance Configuration
     # ========================================================================
+    GOVERNANCE_KEY_DIR: str = os.getenv("GOVERNANCE_KEY_DIR", "/var/lib/metaserver/keys")
+    # Used only for first-time cold start when Redis has no persisted mode key yet.
     DEFAULT_EXECUTION_MODE: str = _get_default_execution_mode()
     DEFAULT_ELEVATION_TTL: int = 300  # 5 minutes
     ELICITATION_TIMEOUT: int = 300  # 5 minutes

--- a/src/meta_mcp/governance/session_key.py
+++ b/src/meta_mcp/governance/session_key.py
@@ -1,0 +1,79 @@
+"""Per-session governance key management."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+import secrets
+from pathlib import Path
+from typing import Optional
+
+from loguru import logger
+from redis import asyncio as aioredis
+
+from ..config import Config
+
+
+GOVERNANCE_SESSION_KEY_HASH_KEY = "governance:session_key_hash"
+
+
+class GovernanceKeyManager:
+    """Manages one-time governance session keys for mode changes."""
+
+    def __init__(self, redis_client: aioredis.Redis):
+        self._redis = redis_client
+        self._current_key: Optional[str] = None
+
+    @staticmethod
+    def generate_key() -> str:
+        """Generate a cryptographically secure 64-character hex key."""
+        return secrets.token_hex(32)
+
+    @staticmethod
+    def _hash_key(key: str) -> str:
+        return hashlib.sha256(key.encode("utf-8")).hexdigest()
+
+    def write_key(self, key: str) -> Path:
+        """Write the governance key to disk with owner-read-only permissions."""
+        key_dir = Path(Config.GOVERNANCE_KEY_DIR)
+        key_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+        os.chmod(key_dir, 0o700)
+
+        key_path = key_dir / "governance.key"
+        key_path.write_text(key, encoding="utf-8")
+        os.chmod(key_path, 0o400)
+        self._current_key = key
+        return key_path
+
+    async def initialize(self) -> Path:
+        """Generate initial key, persist it, and store only hash in Redis."""
+        key = self.generate_key()
+        path = self.write_key(key)
+        await self._redis.set(GOVERNANCE_SESSION_KEY_HASH_KEY, self._hash_key(key))
+        return path
+
+    async def validate_and_rotate(self, provided_key: str) -> bool:
+        """Validate provided key and rotate to a new key when valid."""
+        current_hash = await self._redis.get(GOVERNANCE_SESSION_KEY_HASH_KEY)
+        provided_hash = self._hash_key(provided_key)
+
+        if not current_hash or not hmac.compare_digest(current_hash, provided_hash):
+            return False
+
+        new_key = self.generate_key()
+        self.write_key(new_key)
+        await self._redis.set(GOVERNANCE_SESSION_KEY_HASH_KEY, self._hash_key(new_key))
+        logger.info("Governance session key rotated after successful mode change")
+        return True
+
+    async def get_current_key_hash(self) -> str:
+        """Return the current key hash stored in Redis."""
+        key_hash = await self._redis.get(GOVERNANCE_SESSION_KEY_HASH_KEY)
+        return key_hash or ""
+
+    def cleanup(self) -> None:
+        """Delete governance key file from disk during shutdown."""
+        key_path = Path(Config.GOVERNANCE_KEY_DIR) / "governance.key"
+        if key_path.exists():
+            key_path.unlink()

--- a/src/meta_mcp/state.py
+++ b/src/meta_mcp/state.py
@@ -7,11 +7,13 @@ from typing import Optional
 from loguru import logger
 from redis import asyncio as aioredis
 
+from .audit import AuditEvent, audit_logger
 from .config import Config
 from .redis_client import close_redis_client, get_redis_client
 
 # Constants
 GOVERNANCE_MODE_KEY = "governance:mode"
+GOVERNANCE_SESSION_KEY_HASH_KEY = "governance:session_key_hash"
 ELEVATION_PREFIX = "elevation:"
 DEFAULT_ELEVATION_TTL = Config.DEFAULT_ELEVATION_TTL
 
@@ -39,6 +41,20 @@ class GovernanceState:
         """Initialize governance state with lazy Redis connection."""
         self._redis_client: Optional[aioredis.Redis] = None
         self._cached_mode: Optional[ExecutionMode] = None
+        self._key_manager: Optional[object] = None
+        self._mode_changes_enabled: bool = True
+
+    def set_key_manager(self, key_manager: Optional[object]) -> None:
+        """Attach governance key manager used for mode changes."""
+        self._key_manager = key_manager
+
+    def disable_mode_changes(self) -> None:
+        """Disable governance mode changes when key management is unavailable."""
+        self._mode_changes_enabled = False
+
+    def enable_mode_changes(self) -> None:
+        """Enable governance mode changes when key management is healthy."""
+        self._mode_changes_enabled = True
 
     @staticmethod
     def _parse_mode(mode_value: Optional[str]) -> Optional[ExecutionMode]:
@@ -146,21 +162,66 @@ class GovernanceState:
             return self._cached_mode
         return self._default_mode()
 
-    async def set_mode(self, mode: ExecutionMode) -> bool:
+    async def set_mode(self, mode: ExecutionMode, session_key: str) -> bool:
         """
-        Set governance mode in Redis.
+        Set governance mode in Redis with one-time session key validation.
 
         Args:
             mode: Execution mode to set
+            session_key: Current governance session key
 
         Returns:
-            True if mode was set successfully, False otherwise
+            True if mode was set successfully
+
+        Raises:
+            PermissionError: If mode changes are disabled or key is invalid
         """
+        if not self._mode_changes_enabled or self._key_manager is None:
+            audit_logger.log(
+                AuditEvent.GOVERNANCE_MODE_CHANGE_DENIED,
+                old_mode=self.get_cached_mode().value,
+                requested_mode=mode.value,
+                key_valid=False,
+                reason="key_management_unavailable",
+            )
+            raise PermissionError("Governance mode changes are currently disabled")
+
+        old_mode = (await self.get_mode()).value
+
+        key_valid = await self._key_manager.validate_and_rotate(session_key)
+        if not key_valid:
+            audit_logger.log(
+                AuditEvent.GOVERNANCE_MODE_CHANGE_DENIED,
+                old_mode=old_mode,
+                requested_mode=mode.value,
+                key_valid=False,
+            )
+            audit_logger.log(
+                AuditEvent.GOVERNANCE_KEY_INVALID,
+                old_mode=old_mode,
+                requested_mode=mode.value,
+                key_valid=False,
+            )
+            raise PermissionError("Invalid governance session key")
+
         try:
             redis = await self._get_redis()
             await redis.set(GOVERNANCE_MODE_KEY, mode.value)
-            logger.info(f"Governance mode set to: {mode.value}")
             self._cached_mode = mode
+            audit_logger.log(
+                AuditEvent.GOVERNANCE_MODE_CHANGE,
+                old_mode=old_mode,
+                requested_mode=mode.value,
+                key_valid=True,
+            )
+            audit_logger.log_mode_change(old_mode=old_mode, new_mode=mode.value, changed_by="session_key")
+            audit_logger.log(
+                AuditEvent.GOVERNANCE_KEY_ROTATED,
+                old_mode=old_mode,
+                requested_mode=mode.value,
+                key_valid=True,
+            )
+            logger.info(f"Governance mode set to: {mode.value}")
             return True
         except (aioredis.ConnectionError, aioredis.TimeoutError) as e:
             logger.error(f"Redis connection failed in set_mode: {e}")
@@ -264,6 +325,8 @@ class GovernanceState:
         """Close Redis connection and pool."""
         await close_redis_client()
         self._redis_client = None
+        self._key_manager = None
+        self._mode_changes_enabled = True
 
 
 # Module-level singleton

--- a/src/meta_mcp/supervisor.py
+++ b/src/meta_mcp/supervisor.py
@@ -21,6 +21,7 @@ from .discovery_utils import format_search_results
 from .governance.approval import get_approval_provider
 from .governance.artifacts import get_artifact_generator
 from .governance.policy import evaluate_policy
+from .governance.session_key import GovernanceKeyManager
 from .governance.tokens import generate_token
 from .leases import lease_manager
 from .middleware import GovernanceMiddleware
@@ -196,6 +197,30 @@ async def lifespan(app):
         # governance_state.get_mode() already handles fail-safe to PERMISSION
         # No need to crash - system will operate in PERMISSION mode
 
+    key_manager = None
+    try:
+        redis = await governance_state._get_redis()
+        key_manager = GovernanceKeyManager(redis)
+        key_path = await key_manager.initialize()
+        governance_state.set_key_manager(key_manager)
+        governance_state.enable_mode_changes()
+        logger.info(
+            f"Governance session key written to {key_path}. "
+            "Use this key to change governance mode."
+        )
+    except Exception as e:
+        governance_state.set_key_manager(None)
+        governance_state.disable_mode_changes()
+        logger.error(
+            f"Failed to initialize governance session key: {e}. "
+            "Falling back to PERMISSION mode with mode changes disabled until restart."
+        )
+        try:
+            redis = await governance_state._get_redis()
+            await redis.set("governance:mode", "permission")
+        except Exception as mode_error:
+            logger.error(f"Failed to enforce PERMISSION mode after key init failure: {mode_error}")
+
     # 2. Load tool registry from YAML configuration
     all_tools = tool_registry.get_all_summaries()
     logger.info(f"Tool registry initialized with {len(all_tools)} tools")
@@ -248,6 +273,8 @@ async def lifespan(app):
 
     # SHUTDOWN
     logger.info(f"{SERVER_NAME} shutting down...")
+    if key_manager is not None:
+        key_manager.cleanup()
     await governance_state.close()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -138,6 +138,20 @@ async def redis_client():
         await close_redis_client()
 
 
+@pytest.fixture(autouse=True)
+def mock_governance_key_validation(monkeypatch):
+    """Default all tests to a valid rotating session key manager unless overridden."""
+
+    class _TestKeyManager:
+        async def validate_and_rotate(self, provided_key: str) -> bool:
+            return True
+
+    governance_state.set_key_manager(_TestKeyManager())
+    governance_state.enable_mode_changes()
+    yield
+    governance_state.set_key_manager(None)
+    governance_state.enable_mode_changes()
+
 # ============================================================================
 # GOVERNANCE MODE FIXTURES
 # ============================================================================
@@ -158,12 +172,12 @@ async def governance_in_read_only(redis_client):
         Resets mode to PERMISSION
     """
     # Set READ_ONLY mode
-    await governance_state.set_mode(ExecutionMode.READ_ONLY)
+    await governance_state.set_mode(ExecutionMode.READ_ONLY, session_key="test-session-key")
 
     yield
 
     # Reset to PERMISSION (fail-safe default)
-    await governance_state.set_mode(ExecutionMode.PERMISSION)
+    await governance_state.set_mode(ExecutionMode.PERMISSION, session_key="test-session-key")
 
 
 @pytest.fixture
@@ -181,12 +195,12 @@ async def governance_in_bypass(redis_client):
         Resets mode to PERMISSION
     """
     # Set BYPASS mode
-    await governance_state.set_mode(ExecutionMode.BYPASS)
+    await governance_state.set_mode(ExecutionMode.BYPASS, session_key="test-session-key")
 
     yield
 
     # Reset to PERMISSION (fail-safe default)
-    await governance_state.set_mode(ExecutionMode.PERMISSION)
+    await governance_state.set_mode(ExecutionMode.PERMISSION, session_key="test-session-key")
 
 
 @pytest.fixture
@@ -204,12 +218,12 @@ async def governance_in_permission(redis_client):
         Resets mode to PERMISSION
     """
     # Set PERMISSION mode (explicit)
-    await governance_state.set_mode(ExecutionMode.PERMISSION)
+    await governance_state.set_mode(ExecutionMode.PERMISSION, session_key="test-session-key")
 
     yield
 
     # Mode already at PERMISSION, no cleanup needed
-    await governance_state.set_mode(ExecutionMode.PERMISSION)
+    await governance_state.set_mode(ExecutionMode.PERMISSION, session_key="test-session-key")
 
 
 # ============================================================================

--- a/tests/integration/test_end_to_end_scenario.py
+++ b/tests/integration/test_end_to_end_scenario.py
@@ -149,7 +149,7 @@ async def test_mode_transition_read_only_to_permission(redis_client):
     5. Existing leases unaffected
     """
     # Step 1: Set READ_ONLY mode
-    await governance_state.set_mode(ExecutionMode.READ_ONLY)
+    await governance_state.set_mode(ExecutionMode.READ_ONLY, session_key="test-session-key")
 
     # Step 2: Check sensitive tool (blocked)
     decision = evaluate_policy(
@@ -168,7 +168,7 @@ async def test_mode_transition_read_only_to_permission(redis_client):
     assert safe_lease is not None
 
     # Step 3: Transition to PERMISSION
-    await governance_state.set_mode(ExecutionMode.PERMISSION)
+    await governance_state.set_mode(ExecutionMode.PERMISSION, session_key="test-session-key")
 
     # Step 4: Check same tool (now requires approval)
     decision = evaluate_policy(
@@ -196,7 +196,7 @@ async def test_mode_transition_permission_to_bypass(redis_client):
     4. Same tool now allowed without approval
     """
     # Step 1: Set PERMISSION mode
-    await governance_state.set_mode(ExecutionMode.PERMISSION)
+    await governance_state.set_mode(ExecutionMode.PERMISSION, session_key="test-session-key")
 
     # Step 2: Sensitive tool requires approval
     decision = evaluate_policy(
@@ -205,7 +205,7 @@ async def test_mode_transition_permission_to_bypass(redis_client):
     assert decision.action == "require_approval"
 
     # Step 3: Transition to BYPASS
-    await governance_state.set_mode(ExecutionMode.BYPASS)
+    await governance_state.set_mode(ExecutionMode.BYPASS, session_key="test-session-key")
 
     # Step 4: Same tool now allowed
     decision = evaluate_policy(
@@ -479,7 +479,7 @@ async def test_complete_user_journey(redis_client):
     12. User must re-approve for more uses
     """
     # Step 1: Start in READ_ONLY
-    await governance_state.set_mode(ExecutionMode.READ_ONLY)
+    await governance_state.set_mode(ExecutionMode.READ_ONLY, session_key="test-session-key")
 
     # Step 2: Search for tools
     results = tool_registry.search("file")
@@ -498,7 +498,7 @@ async def test_complete_user_journey(redis_client):
     assert sensitive_decision.action == "block"
 
     # Step 5: Elevate to PERMISSION
-    await governance_state.set_mode(ExecutionMode.PERMISSION)
+    await governance_state.set_mode(ExecutionMode.PERMISSION, session_key="test-session-key")
 
     # Step 6: Request sensitive tool
     sensitive_decision = evaluate_policy(
@@ -575,9 +575,9 @@ async def test_security_invariants_maintained(redis_client, fresh_registry):
     assert expired is None
 
     # Invariant 5: Mode changes don't affect existing leases
-    await governance_state.set_mode(ExecutionMode.PERMISSION)
+    await governance_state.set_mode(ExecutionMode.PERMISSION, session_key="test-session-key")
     lease = await lease_manager.grant("mode_test", "tool_c", 300, 5, "PERMISSION")
-    await governance_state.set_mode(ExecutionMode.READ_ONLY)
+    await governance_state.set_mode(ExecutionMode.READ_ONLY, session_key="test-session-key")
     validated = await lease_manager.validate("mode_test", "tool_c")
     assert validated is not None
     assert validated.mode_at_issue == "PERMISSION"

--- a/tests/integration/test_lease_governance_flow.py
+++ b/tests/integration/test_lease_governance_flow.py
@@ -432,7 +432,7 @@ async def test_mode_change_doesnt_affect_existing_leases(redis_client):
     4. New leases follow new mode
     """
     # Set PERMISSION mode
-    await governance_state.set_mode(ExecutionMode.PERMISSION)
+    await governance_state.set_mode(ExecutionMode.PERMISSION, session_key="test-session-key")
 
     # Grant lease in PERMISSION mode
     lease = await lease_manager.grant(
@@ -446,7 +446,7 @@ async def test_mode_change_doesnt_affect_existing_leases(redis_client):
     assert lease.mode_at_issue == "PERMISSION"
 
     # Change to READ_ONLY mode
-    await governance_state.set_mode(ExecutionMode.READ_ONLY)
+    await governance_state.set_mode(ExecutionMode.READ_ONLY, session_key="test-session-key")
 
     # Existing lease still valid
     validated = await lease_manager.validate("mode_change_test", "write_file")

--- a/tests/test_governance_integration.py
+++ b/tests/test_governance_integration.py
@@ -164,7 +164,7 @@ async def test_mode_change_affects_new_lease_grants(
         await get_tool_schema.fn(tool_name="write_file", ctx=mock_fastmcp_context)
 
     # Change mode to BYPASS
-    await governance_state.set_mode(ExecutionMode.BYPASS)
+    await governance_state.set_mode(ExecutionMode.BYPASS, session_key="test-session-key")
 
     # Request schema for delete_file
     response = await get_tool_schema.fn(tool_name="delete_file", ctx=mock_fastmcp_context)
@@ -197,7 +197,7 @@ async def test_existing_leases_remain_valid_after_mode_change(
     assert lease is not None
 
     # Change mode to READ_ONLY
-    await governance_state.set_mode(ExecutionMode.READ_ONLY)
+    await governance_state.set_mode(ExecutionMode.READ_ONLY, session_key="test-session-key")
 
     # Verify lease still valid
     lease_check = await lease_manager.validate(client_id, "write_file")
@@ -226,7 +226,7 @@ async def test_policy_matrix_integration(
     mock_fastmcp_context.session_id = client_id
 
     # Test READ_ONLY + safe
-    await governance_state.set_mode(ExecutionMode.READ_ONLY)
+    await governance_state.set_mode(ExecutionMode.READ_ONLY, session_key="test-session-key")
     response = await get_tool_schema.fn(tool_name="read_file", ctx=mock_fastmcp_context)
     assert json.loads(response)["name"] == "read_file"
 
@@ -235,7 +235,7 @@ async def test_policy_matrix_integration(
         await get_tool_schema.fn(tool_name="write_file", ctx=mock_fastmcp_context)
 
     # Test PERMISSION + safe
-    await governance_state.set_mode(ExecutionMode.PERMISSION)
+    await governance_state.set_mode(ExecutionMode.PERMISSION, session_key="test-session-key")
     response = await get_tool_schema.fn(tool_name="read_file", ctx=mock_fastmcp_context)
     assert json.loads(response)["name"] == "read_file"
 
@@ -244,7 +244,7 @@ async def test_policy_matrix_integration(
         await get_tool_schema.fn(tool_name="write_file", ctx=mock_fastmcp_context)
 
     # Test BYPASS + any
-    await governance_state.set_mode(ExecutionMode.BYPASS)
+    await governance_state.set_mode(ExecutionMode.BYPASS, session_key="test-session-key")
     response = await get_tool_schema.fn(tool_name="delete_file", ctx=mock_fastmcp_context)
     assert json.loads(response)["name"] == "delete_file"
 

--- a/tests/test_governance_session_key.py
+++ b/tests/test_governance_session_key.py
@@ -1,0 +1,226 @@
+import hashlib
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from src.meta_mcp.config import Config
+from src.meta_mcp.governance.session_key import GovernanceKeyManager
+from src.meta_mcp.state import ExecutionMode, GovernanceState
+
+
+class FakeRedis:
+    def __init__(self):
+        self.data = {}
+
+    async def get(self, key):
+        return self.data.get(key)
+
+    async def set(self, key, value):
+        self.data[key] = value
+        return True
+
+
+@pytest.mark.asyncio
+async def test_key_generation_is_random():
+    manager = GovernanceKeyManager(FakeRedis())
+    assert manager.generate_key() != manager.generate_key()
+
+
+@pytest.mark.asyncio
+async def test_key_file_written_with_restrictive_permissions(tmp_path, monkeypatch):
+    monkeypatch.setattr(Config, "GOVERNANCE_KEY_DIR", str(tmp_path))
+    manager = GovernanceKeyManager(FakeRedis())
+    path = manager.write_key(manager.generate_key())
+    assert path.stat().st_mode & 0o777 == 0o400
+
+
+@pytest.mark.asyncio
+async def test_key_file_written_to_configured_directory(tmp_path, monkeypatch):
+    monkeypatch.setattr(Config, "GOVERNANCE_KEY_DIR", str(tmp_path))
+    manager = GovernanceKeyManager(FakeRedis())
+    key = manager.generate_key()
+    path = manager.write_key(key)
+    assert path == tmp_path / "governance.key"
+    assert path.read_text(encoding="utf-8") == key
+
+
+@pytest.mark.asyncio
+async def test_set_mode_requires_valid_key(tmp_path, monkeypatch):
+    monkeypatch.setattr(Config, "GOVERNANCE_KEY_DIR", str(tmp_path))
+    state = GovernanceState()
+    redis = FakeRedis()
+    manager = GovernanceKeyManager(redis)
+    await manager.initialize()
+    state.set_key_manager(manager)
+    state.enable_mode_changes()
+    state._get_redis = AsyncMock(return_value=redis)
+
+    with pytest.raises(PermissionError, match="Invalid governance session key"):
+        await state.set_mode(ExecutionMode.BYPASS, session_key="wrong-key")
+
+
+@pytest.mark.asyncio
+async def test_set_mode_with_valid_key_succeeds(tmp_path, monkeypatch):
+    monkeypatch.setattr(Config, "GOVERNANCE_KEY_DIR", str(tmp_path))
+    state = GovernanceState()
+    redis = FakeRedis()
+    manager = GovernanceKeyManager(redis)
+    path = await manager.initialize()
+    state.set_key_manager(manager)
+    state.enable_mode_changes()
+    state._get_redis = AsyncMock(return_value=redis)
+
+    key = path.read_text(encoding="utf-8")
+    changed = await state.set_mode(ExecutionMode.READ_ONLY, session_key=key)
+
+    assert changed is True
+    assert await state.get_mode() == ExecutionMode.READ_ONLY
+
+
+@pytest.mark.asyncio
+async def test_key_rotated_after_use(tmp_path, monkeypatch):
+    monkeypatch.setattr(Config, "GOVERNANCE_KEY_DIR", str(tmp_path))
+    state = GovernanceState()
+    redis = FakeRedis()
+    manager = GovernanceKeyManager(redis)
+    path = await manager.initialize()
+    state.set_key_manager(manager)
+    state.enable_mode_changes()
+    state._get_redis = AsyncMock(return_value=redis)
+
+    old_key = path.read_text(encoding="utf-8")
+    await state.set_mode(ExecutionMode.READ_ONLY, session_key=old_key)
+    with pytest.raises(PermissionError):
+        await state.set_mode(ExecutionMode.PERMISSION, session_key=old_key)
+
+
+@pytest.mark.asyncio
+async def test_new_key_written_after_rotation(tmp_path, monkeypatch):
+    monkeypatch.setattr(Config, "GOVERNANCE_KEY_DIR", str(tmp_path))
+    state = GovernanceState()
+    redis = FakeRedis()
+    manager = GovernanceKeyManager(redis)
+    path = await manager.initialize()
+    state.set_key_manager(manager)
+    state.enable_mode_changes()
+    state._get_redis = AsyncMock(return_value=redis)
+
+    old_key = path.read_text(encoding="utf-8")
+    await state.set_mode(ExecutionMode.BYPASS, session_key=old_key)
+    assert path.read_text(encoding="utf-8") != old_key
+
+
+@pytest.mark.asyncio
+async def test_constant_time_comparison(tmp_path, monkeypatch):
+    monkeypatch.setattr(Config, "GOVERNANCE_KEY_DIR", str(tmp_path))
+    manager = GovernanceKeyManager(FakeRedis())
+    path = await manager.initialize()
+    key = path.read_text(encoding="utf-8")
+
+    with patch("src.meta_mcp.governance.session_key.hmac.compare_digest", return_value=True) as mock_cmp:
+        assert await manager.validate_and_rotate(key) is True
+        assert mock_cmp.called
+
+
+@pytest.mark.asyncio
+async def test_key_hash_stored_in_redis_not_raw(tmp_path, monkeypatch):
+    monkeypatch.setattr(Config, "GOVERNANCE_KEY_DIR", str(tmp_path))
+    redis = FakeRedis()
+    manager = GovernanceKeyManager(redis)
+    path = await manager.initialize()
+    key = path.read_text(encoding="utf-8")
+
+    stored = await redis.get("governance:session_key_hash")
+    assert stored == hashlib.sha256(key.encode("utf-8")).hexdigest()
+    assert stored != key
+
+
+@pytest.mark.asyncio
+async def test_startup_generates_key(tmp_path, monkeypatch):
+    monkeypatch.setattr(Config, "GOVERNANCE_KEY_DIR", str(tmp_path))
+    from src.meta_mcp import supervisor
+
+    fake_redis = FakeRedis()
+    monkeypatch.setattr(supervisor, "check_redis_health", AsyncMock(return_value=(True, "ok")))
+    monkeypatch.setattr(supervisor.governance_state, "_get_redis", AsyncMock(return_value=fake_redis))
+    monkeypatch.setattr(supervisor.governance_state, "get_mode", AsyncMock(return_value=ExecutionMode.PERMISSION))
+    monkeypatch.setattr(supervisor, "run_all_validations", AsyncMock(return_value=None))
+    provider = type("P", (), {"is_available": AsyncMock(return_value=True), "get_name": lambda self: "mock"})()
+    monkeypatch.setattr(supervisor, "get_approval_provider", AsyncMock(return_value=provider))
+    monkeypatch.setattr(supervisor, "get_artifact_generator", lambda: type("A", (), {"artifacts_root": tmp_path})())
+
+    async with supervisor.lifespan(None):
+        assert (tmp_path / "governance.key").exists()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_cleans_key_file(tmp_path, monkeypatch):
+    monkeypatch.setattr(Config, "GOVERNANCE_KEY_DIR", str(tmp_path))
+    from src.meta_mcp import supervisor
+
+    fake_redis = FakeRedis()
+    monkeypatch.setattr(supervisor, "check_redis_health", AsyncMock(return_value=(True, "ok")))
+    monkeypatch.setattr(supervisor.governance_state, "_get_redis", AsyncMock(return_value=fake_redis))
+    monkeypatch.setattr(supervisor.governance_state, "get_mode", AsyncMock(return_value=ExecutionMode.PERMISSION))
+    monkeypatch.setattr(supervisor, "run_all_validations", AsyncMock(return_value=None))
+    provider = type("P", (), {"is_available": AsyncMock(return_value=True), "get_name": lambda self: "mock"})()
+    monkeypatch.setattr(supervisor, "get_approval_provider", AsyncMock(return_value=provider))
+    monkeypatch.setattr(supervisor, "get_artifact_generator", lambda: type("A", (), {"artifacts_root": tmp_path})())
+
+    async with supervisor.lifespan(None):
+        pass
+
+    assert not (tmp_path / "governance.key").exists()
+
+
+@pytest.mark.asyncio
+async def test_invalid_key_attempt_is_audited(tmp_path, monkeypatch):
+    monkeypatch.setattr(Config, "GOVERNANCE_KEY_DIR", str(tmp_path))
+    state = GovernanceState()
+    redis = FakeRedis()
+    manager = GovernanceKeyManager(redis)
+    await manager.initialize()
+    state.set_key_manager(manager)
+    state.enable_mode_changes()
+    state._get_redis = AsyncMock(return_value=redis)
+
+    with patch("src.meta_mcp.state.audit_logger.log") as mock_log:
+        with pytest.raises(PermissionError):
+            await state.set_mode(ExecutionMode.BYPASS, session_key="bad")
+    assert any(call.kwargs.get("key_valid") is False for call in mock_log.mock_calls)
+
+
+@pytest.mark.asyncio
+async def test_successful_mode_change_is_audited(tmp_path, monkeypatch):
+    monkeypatch.setattr(Config, "GOVERNANCE_KEY_DIR", str(tmp_path))
+    state = GovernanceState()
+    redis = FakeRedis()
+    manager = GovernanceKeyManager(redis)
+    path = await manager.initialize()
+    state.set_key_manager(manager)
+    state.enable_mode_changes()
+    state._get_redis = AsyncMock(return_value=redis)
+
+    with patch("src.meta_mcp.state.audit_logger.log") as mock_log:
+        await state.set_mode(
+            ExecutionMode.BYPASS,
+            session_key=path.read_text(encoding="utf-8"),
+        )
+    assert any(call.kwargs.get("requested_mode") == "bypass" for call in mock_log.mock_calls)
+
+
+@pytest.mark.asyncio
+async def test_default_governance_mode_only_cold_start(monkeypatch):
+    monkeypatch.setattr(Config, "DEFAULT_EXECUTION_MODE", "read_only")
+    state = GovernanceState()
+    redis = FakeRedis()
+    state._get_redis = AsyncMock(return_value=redis)
+
+    first = await state.get_mode()
+    assert first == ExecutionMode.READ_ONLY
+
+    await redis.set("governance:mode", "permission")
+    monkeypatch.setattr(Config, "DEFAULT_EXECUTION_MODE", "bypass")
+
+    second = await state.get_mode()
+    assert second == ExecutionMode.PERMISSION

--- a/tests/test_lease_security.py
+++ b/tests/test_lease_security.py
@@ -259,7 +259,7 @@ async def test_lease_mode_consistency(redis_client, governance_in_permission):
     )
     assert lease.mode_at_issue == "PERMISSION"
 
-    await governance_state.set_mode(ExecutionMode.READ_ONLY)
+    await governance_state.set_mode(ExecutionMode.READ_ONLY, session_key="test-session-key")
 
     valid = await lease_manager.validate("test_session", "write_file")
     assert valid is not None, "Lease remains valid after mode change"

--- a/tests/test_progressive_discovery.py
+++ b/tests/test_progressive_discovery.py
@@ -210,7 +210,7 @@ async def test_governance_intercepts_all_tools(redis_client):
     Even with progressive discovery, governance must still apply.
     """
     # Set governance mode to READ_ONLY
-    await governance_state.set_mode(ExecutionMode.READ_ONLY)
+    await governance_state.set_mode(ExecutionMode.READ_ONLY, session_key="test-session-key")
 
     tools_before = await mcp.get_tools()
     tool_names_before = [t.name for t in tools_before.values()]
@@ -229,7 +229,7 @@ async def test_governance_intercepts_all_tools(redis_client):
     # Note: Actual governance interception is tested in test_governance_modes.py
 
     # Clean up: reset to PERMISSION mode
-    await governance_state.set_mode(ExecutionMode.PERMISSION)
+    await governance_state.set_mode(ExecutionMode.PERMISSION, session_key="test-session-key")
 
 
 @pytest.mark.asyncio

--- a/tests/test_redis_pooling.py
+++ b/tests/test_redis_pooling.py
@@ -16,7 +16,7 @@ async def test_shared_pool_reuse(redis_client):
     governance_state._redis_client = None
 
     async def run_governance():
-        await governance_state.set_mode(ExecutionMode.PERMISSION)
+        await governance_state.set_mode(ExecutionMode.PERMISSION, session_key="test-session-key")
         await governance_state.get_mode()
 
     async def run_lease(index: int):


### PR DESCRIPTION
Superseded by #228 which was merged with:
- Lazy imports in `governance/__init__.py` (prevents circular deps)
- Tighter encapsulation (GovernanceState owns key manager lifecycle)
- `conftest.py` autouse fixture for cleaner test setup
- `force_mode()` for startup fail-safe path
- Cleaner audit logging (one event per action)

Both PRs had the same `PermissionError` bug on key rotation (file set to 0o400 couldn't be overwritten). Fixed in #228 by unlinking before write.